### PR TITLE
Reproduction test case with an shading issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: xenial
 language: scala
 
 script:
-  - sbt "+test" "publishLocal;scripted"
+  - sbt "+test" "publishLocal; toShade/publishLocal ;scripted"
 
 env: ADOPTOPENJDK=11
 

--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,18 @@ lazy val sbtplugin = project
     scriptedBufferLog := false
   })
 
+
+lazy val toShade = (project in file("some-random-library"))
+  .settings(
+    // same base settings as the scripted test
+    organization := "com.example",
+    name := "some-random-library",
+    version := "0.1.0-SNAPSHOT",
+    scalaVersion := "2.13.1",
+
+    publish := {}
+  )
+
 ThisBuild / scmInfo := Some(
   ScmInfo(
     url("https://github.com/eed3si9n/jarjar-abrams"),

--- a/sbtplugin/src/sbt-test/actions/trait/build.sbt
+++ b/sbtplugin/src/sbt-test/actions/trait/build.sbt
@@ -1,0 +1,17 @@
+ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / organization := "com.example"
+ThisBuild / scalaVersion := "2.13.1"
+
+lazy val shadedLibrary = project
+  .enablePlugins(JarjarAbramsPlugin)
+  .settings(
+    name := "shaded-json4s-ast",
+    jarjarLibraryDependency := "com.example" %% "some-random-library" % "0.1.0-SNAPSHOT",
+    jarjarShadeRules += ShadeRuleBuilder.moveUnder("example", "shaded")
+  )
+
+lazy val use = project
+  .settings(
+    publish := {}
+  )
+  .dependsOn(shadedLibrary)

--- a/sbtplugin/src/sbt-test/actions/trait/project/build.properties
+++ b/sbtplugin/src/sbt-test/actions/trait/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.10

--- a/sbtplugin/src/sbt-test/actions/trait/project/plugins.sbt
+++ b/sbtplugin/src/sbt-test/actions/trait/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.eed3si9n.jarjarabrams" % "sbt-jarjar-abrams" % "0.3.0")
+

--- a/sbtplugin/src/sbt-test/actions/trait/test
+++ b/sbtplugin/src/sbt-test/actions/trait/test
@@ -1,0 +1,4 @@
+# > shadedLibrary/publishLocal
+> show shadedLibrary/makePom
+
+> use/run

--- a/sbtplugin/src/sbt-test/actions/trait/use/src/main/scala/Test.scala
+++ b/sbtplugin/src/sbt-test/actions/trait/use/src/main/scala/Test.scala
@@ -1,0 +1,9 @@
+package example
+
+import shaded.example._
+
+class DependsOn extends shaded.example.ATraitWithAVal
+
+object ApplicationMain extends App {
+  new DependsOn
+}

--- a/some-random-library/src/main/scala/Test.scala
+++ b/some-random-library/src/main/scala/Test.scala
@@ -1,0 +1,7 @@
+package example
+
+final case class Thing(params: String)
+
+trait ATraitWithAVal {
+  val thing = Thing("value")
+}


### PR DESCRIPTION
Hi thanks for the library, it's currently saving our asses (I'm sad to say, but we have to shade some libraries).

While working with the library, we noticed one issue with it. This pull request only includes a reproduction case and hopefully the CI can run and show the error.

I would be more than happy to provide a fix for it. I would just like to ask if that's possible at all (I'm not sure because the issue seems to come from a low level compiler behaviour).

Here is the stack (explanation follows):

```
[info] [info] Non-compiled module 'compiler-bridge_2.13' for Scala 2.13.1. Compiling...
[info] 8 warnings found
[info] [info]   Compilation completed in 8.449s.
[info] [info] Done compiling.
[info] [info] running example.ApplicationMain
[info] [error] (run-main-0) java.lang.AbstractMethodError: example.DependsOn.example$ATraitWithAVal$_setter_$thing_$eq(Lshaded/example/Thing;)V
[info] [error] java.lang.AbstractMethodError: example.DependsOn.example$ATraitWithAVal$_setter_$thing_$eq(Lshaded/example/Thing;)V
[info] [error] 	at shaded.example.ATraitWithAVal.$init$(Test.scala:6)
[info] [error] 	at example.DependsOn.<init>(Test.scala:5)
[info] [error] 	at example.ApplicationMain$.<clinit>(Test.scala:8)
[info] [error] nat example.ApplicationMain.main(Test.scala)
[info] [error] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[info] [error] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[info] [error] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[info] [error] 	at java.lang.reflect.Method.invoke(Method.java:498)
[info] [error] stack trace is suppressed; run 'last use / Compile / bgRun' for the full output
[info] [error] Nonzero exit code: 1
[info] [error] (use / Compile / run) Nonzero exit code: 1
[info] [error] Total time: 10 s, completed 7-Oct-2020 10:15:38 AM
```

Let's say I'm trying to shade `com.example:some-library`. This library is a Scala library and it has a `trait` defined like so:

```
package example

final case class Thing(params: String)

trait ATraitWithAVal {
  val thing = Thing("value")
}
```

In this instance, the `val` inside the trait is compiled in a very specific way to be a Java interface. A setter will be introduced and called during initialization. The setter will look like:
```java
public abstract ATraitWithAVal$_setter_$thing$eq(example.Thing s);
```

When we shade, I believe we should rename those as well, because otherwise, extending the shaded trait raise an error like shown above. (more info at https://stackoverflow.com/questions/43446423/using-val-in-scala-trait).

Do you think it's possible to fix this, if yes, let me know, I'll look into it more carefully and try to fix it.