### PR TITLE
Fix bug when shading ScalaLongSignature

### DIFF
--- a/core/src/main/scala/com/eed3si9n/jarjarabrams/scalasig/ScalaSigAnnotationVisitor.scala
+++ b/core/src/main/scala/com/eed3si9n/jarjarabrams/scalasig/ScalaSigAnnotationVisitor.scala
@@ -27,6 +27,7 @@ class ScalaSigAnnotationVisitor(
 
   private val MaxStringSizeInBytes = 65535
   private val annotationBytes: ByteArrayOutputStream = new ByteArrayOutputStream()
+  private var hasWrittenAnnotation = false
 
   override def visit(name: String, value: Any): Unit = {
     // Append all the annotation bytes, whether is is a long or normal signature
@@ -40,6 +41,15 @@ class ScalaSigAnnotationVisitor(
   }
 
   override def visitEnd(): Unit = {
+    if (!hasWrittenAnnotation) {
+      // This method is called as many times as visit() was called,
+      // but we only want to write the annotation once
+      rewriteAnnotation()
+      hasWrittenAnnotation = true
+    }
+  }
+
+  def rewriteAnnotation(): Unit = {
     val encoded = annotationBytes.toByteArray
     val len = ByteCodecs.decode(encoded)
 


### PR DESCRIPTION
When shading a `@ScalaLongSignature(bytes = Array())`, ASM calls `visit()` for each item in the bytes array, and then calls `visitEnd()` for each time `visit()` was called as well.

In visitEnd() we write the rewritten ScalaLongSignature completely, so this causes jarjar-abrams to write the ScalaLongSignature multiple times.

When reflecting on one of these classes, we get an error:
```
java.lang.annotation.AnnotationFormatError: Duplicate annotation for class: interface scala.reflect.ScalaLongSignature: @scala.reflect.ScalaLongSignature(
```

A decompilation of the affected class shows that the class is annotated multiple times with `@scala.reflect.ScalaLongSignature` .


This fixes the issue by making sure we only call `rewriteAnnotation` once for the lifetime of the class. I tested this, and it solved the issue :)

I imagine the issue wasn't caught earlier because running into this requires you to reflect/use typetags on very very large scala classes which have been rewritten by jarjar-abrams, which is likely rare.