### PR TITLE
Add jarjar-assembly.jar uber jar in publish

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,6 +13,10 @@ In 2004, herbyderby (Chris Nokleberg) created a tool called Jar Jar Links that c
 
 Now defunct [fork of Jar Jar Links by Pants](https://github.com/pantsbuild/jarjar) was in-sourced at commit 57845dc73d3e2c9b916ae4a788cfa12114fd7df1, dated Oct 28, 2018.
 
+### Jar Jar Uber Jar
+
+Published as: `"com.eed3si9n.jarjar" % "jarjar-assembly" % <version>`
+
 ## License
 
 Licensed under the Apache License, Version 2.0.

--- a/build.sbt
+++ b/build.sbt
@@ -52,9 +52,20 @@ lazy val jarjar = project
     }
   })
 
+lazy val jarjar_assembly = project
+  .settings(nocomma {
+    organization := "com.eed3si9n.jarjar"
+    crossScalaVersions := Vector(scala212)
+    crossPaths := false
+    autoScalaLibrary := false
+    name := "JarJar Assembly"
+    Compile / packageBin := (jarjar / assembly).value
+  })
+
 lazy val core = project
   .enablePlugins(ContrabandPlugin)
   .dependsOn(jarjar)
+  .aggregate(jarjar_assembly)
   .settings(nocomma {
     name := "jarjar-abrams-core"
 


### PR DESCRIPTION
```
sbt:jarjar-abrams> publishLocal
[info] Wrote /Users/eric/dd/jarjar-abrams/core/target/scala-2.12/jarjar-abrams-core_2.12-1.8.1-SNAPSHOT.pom
[info] Wrote /Users/eric/dd/jarjar-abrams/jarjar/target/jarjar-1.8.1-SNAPSHOT.pom
[info] Wrote /Users/eric/dd/jarjar-abrams/sbtplugin/target/scala-2.12/sbt-1.0/sbt-jarjar-abrams-1.8.1-SNAPSHOT.pom
[info] Wrote /Users/eric/dd/jarjar-abrams/target/scala-2.12/jarjar-abrams_2.12-1.8.1-SNAPSHOT.pom
[info] Wrote /Users/eric/dd/jarjar-abrams/jarjar_assembly/target/jarjar-assembly-1.8.1-SNAPSHOT.pom
[info] :: delivering :: com.eed3si9n.jarjarabrams#jarjar-abrams_2.12;1.8.1-SNAPSHOT :: 1.8.1-SNAPSHOT :: integration :: Mon Oct 25 13:59:43 PDT 2021
[info] 	delivering ivy file to /Users/eric/dd/jarjar-abrams/target/scala-2.12/ivy-1.8.1-SNAPSHOT.xml
[info] 	published jarjar-abrams_2.12 to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/jarjar-abrams_2.12/1.8.1-SNAPSHOT/poms/jarjar-abrams_2.12.pom
[info] 	published jarjar-abrams_2.12 to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/jarjar-abrams_2.12/1.8.1-SNAPSHOT/jars/jarjar-abrams_2.12.jar
[info] 	published jarjar-abrams_2.12 to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/jarjar-abrams_2.12/1.8.1-SNAPSHOT/srcs/jarjar-abrams_2.12-sources.jar
[info] 	published jarjar-abrams_2.12 to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/jarjar-abrams_2.12/1.8.1-SNAPSHOT/docs/jarjar-abrams_2.12-javadoc.jar
[info] 	published ivy to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/jarjar-abrams_2.12/1.8.1-SNAPSHOT/ivys/ivy.xml
[info] :: delivering :: com.eed3si9n.jarjar#jarjar;1.8.1-SNAPSHOT :: 1.8.1-SNAPSHOT :: integration :: Mon Oct 25 13:59:43 PDT 2021
[info] 	delivering ivy file to /Users/eric/dd/jarjar-abrams/jarjar/target/ivy-1.8.1-SNAPSHOT.xml
[info] 	published jarjar to /Users/eric/.ivy2/local/com.eed3si9n.jarjar/jarjar/1.8.1-SNAPSHOT/poms/jarjar.pom
[info] 	published jarjar to /Users/eric/.ivy2/local/com.eed3si9n.jarjar/jarjar/1.8.1-SNAPSHOT/jars/jarjar.jar
[info] 	published jarjar to /Users/eric/.ivy2/local/com.eed3si9n.jarjar/jarjar/1.8.1-SNAPSHOT/srcs/jarjar-sources.jar
[info] 	published jarjar to /Users/eric/.ivy2/local/com.eed3si9n.jarjar/jarjar/1.8.1-SNAPSHOT/docs/jarjar-javadoc.jar
[info] 	published ivy to /Users/eric/.ivy2/local/com.eed3si9n.jarjar/jarjar/1.8.1-SNAPSHOT/ivys/ivy.xml
[info] :: delivering :: com.eed3si9n.jarjarabrams#jarjar-abrams-core_2.12;1.8.1-SNAPSHOT :: 1.8.1-SNAPSHOT :: integration :: Mon Oct 25 13:59:43 PDT 2021
[info] 	delivering ivy file to /Users/eric/dd/jarjar-abrams/core/target/scala-2.12/ivy-1.8.1-SNAPSHOT.xml
[info] 	published jarjar-abrams-core_2.12 to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/jarjar-abrams-core_2.12/1.8.1-SNAPSHOT/poms/jarjar-abrams-core_2.12.pom
[info] 	published jarjar-abrams-core_2.12 to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/jarjar-abrams-core_2.12/1.8.1-SNAPSHOT/jars/jarjar-abrams-core_2.12.jar
[info] 	published jarjar-abrams-core_2.12 to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/jarjar-abrams-core_2.12/1.8.1-SNAPSHOT/srcs/jarjar-abrams-core_2.12-sources.jar
[info] 	published jarjar-abrams-core_2.12 to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/jarjar-abrams-core_2.12/1.8.1-SNAPSHOT/docs/jarjar-abrams-core_2.12-javadoc.jar
[info] 	published ivy to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/jarjar-abrams-core_2.12/1.8.1-SNAPSHOT/ivys/ivy.xml
[info] :: delivering :: com.eed3si9n.jarjarabrams#sbt-jarjar-abrams;1.8.1-SNAPSHOT :: 1.8.1-SNAPSHOT :: integration :: Mon Oct 25 13:59:43 PDT 2021
[info] 	delivering ivy file to /Users/eric/dd/jarjar-abrams/sbtplugin/target/scala-2.12/sbt-1.0/ivy-1.8.1-SNAPSHOT.xml
[info] 	published sbt-jarjar-abrams to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/sbt-jarjar-abrams/scala_2.12/sbt_1.0/1.8.1-SNAPSHOT/poms/sbt-jarjar-abrams.pom
[info] 	published sbt-jarjar-abrams to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/sbt-jarjar-abrams/scala_2.12/sbt_1.0/1.8.1-SNAPSHOT/jars/sbt-jarjar-abrams.jar
[info] 	published sbt-jarjar-abrams to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/sbt-jarjar-abrams/scala_2.12/sbt_1.0/1.8.1-SNAPSHOT/srcs/sbt-jarjar-abrams-sources.jar
[info] 	published sbt-jarjar-abrams to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/sbt-jarjar-abrams/scala_2.12/sbt_1.0/1.8.1-SNAPSHOT/docs/sbt-jarjar-abrams-javadoc.jar
[info] 	published ivy to /Users/eric/.ivy2/local/com.eed3si9n.jarjarabrams/sbt-jarjar-abrams/scala_2.12/sbt_1.0/1.8.1-SNAPSHOT/ivys/ivy.xml
[info] Strategy 'discard' was applied to 20 files (Run the task at debug level to see details)
[info] Assembly up to date: /Users/eric/dd/jarjar-abrams/jarjar/target/jarjar-assembly-1.8.1-SNAPSHOT.jar
[info] :: delivering :: com.eed3si9n.jarjar#jarjar-assembly;1.8.1-SNAPSHOT :: 1.8.1-SNAPSHOT :: integration :: Mon Oct 25 13:59:44 PDT 2021
[info] 	delivering ivy file to /Users/eric/dd/jarjar-abrams/jarjar_assembly/target/ivy-1.8.1-SNAPSHOT.xml
[info] 	published jarjar-assembly to /Users/eric/.ivy2/local/com.eed3si9n.jarjar/jarjar-assembly/1.8.1-SNAPSHOT/poms/jarjar-assembly.pom
[info] 	published jarjar-assembly to /Users/eric/.ivy2/local/com.eed3si9n.jarjar/jarjar-assembly/1.8.1-SNAPSHOT/jars/jarjar-assembly.jar
[info] 	published jarjar-assembly to /Users/eric/.ivy2/local/com.eed3si9n.jarjar/jarjar-assembly/1.8.1-SNAPSHOT/srcs/jarjar-assembly-sources.jar
[info] 	published jarjar-assembly to /Users/eric/.ivy2/local/com.eed3si9n.jarjar/jarjar-assembly/1.8.1-SNAPSHOT/docs/jarjar-assembly-javadoc.jar
[info] 	published ivy to /Users/eric/.ivy2/local/com.eed3si9n.jarjar/jarjar-assembly/1.8.1-SNAPSHOT/ivys/ivy.xml
[success] Total time: 1 s, completed Oct 25, 2021 1:59:44 PM
sbt:jarjar-abrams>
```