### PR TITLE
Fix random "UTF8 string too large" exception in ScalaSigAnnotationVisitor

### DIFF
--- a/core/src/test/scala/testpkg/ScalaSigAnnotationVisitorSpec.scala
+++ b/core/src/test/scala/testpkg/ScalaSigAnnotationVisitorSpec.scala
@@ -1,0 +1,25 @@
+package testpkg
+
+import verify._
+import com.eed3si9n.jarjarabrams.scalasig.ScalaSigAnnotationVisitor
+
+object ScalaSigAnnotationVisitorSpec extends BasicTestSuite {
+  test("nextChunk") {
+    import ScalaSigAnnotationVisitor.nextChunk
+
+    val chars1 = Array('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h')
+    assert(nextChunk(chars1, chars1.length, 3).toSeq.isEmpty)
+    assert(nextChunk(chars1, 0, 3).toSeq == Seq('a', 'b', 'c'))
+    assert(nextChunk(chars1, 3, 3).toSeq == Seq('d', 'e', 'f'))
+    assert(nextChunk(chars1, 6, 3).toSeq == Seq('g', 'h'))
+
+    val chars2 = Array('\u0000', 'a', 'b', 'c', 'd', 'e', '\u0000', 'g', '\u0000')
+    assert(nextChunk(chars2, 0, 3).toSeq == Seq('\u0000', 'a'))
+    assert(nextChunk(chars2, 2, 3).toSeq == Seq('b', 'c', 'd'))
+    assert(nextChunk(chars2, 5, 3).toSeq == Seq('e', '\u0000'))
+    assert(nextChunk(chars2, 5, 2).toSeq == Seq('e'))
+    assert(nextChunk(chars2, 7, 3).toSeq == Seq('g', '\u0000'))
+    assert(nextChunk(chars2, 7, 2).toSeq == Seq('g'))
+    assert(nextChunk(chars2, 8, 2).toSeq == Seq('\u0000'))
+  }
+}


### PR DESCRIPTION
This PR fixes  random "UTF8 string too large" exception during shading, which I encountered in my closed source project. This exception is very hard to reproduce because it occurs during processing classes that have `ScalaLongSignature` annotation and annotation value should have zero bytes in certain places, which is not deterministic. The cause of this bug is `nextChunk` function in `ScalaSigAnnotationVisitor` class  which can produce chunks equal to `65536` bytes breaking `org.objectweb.asm.ByteVector#putUTF8`. Stack trace for exception is following:
```
java.lang.IllegalArgumentException: UTF8 string too large
     at org.objectweb.asm.ByteVector.encodeUtf8(ByteVector.java:298)
     at org.objectweb.asm.ByteVector.putUTF8(ByteVector.java:265)
     at org.objectweb.asm.SymbolTable.addConstantUtf8(SymbolTable.java:774)
     at org.objectweb.asm.AnnotationWriter.visit(AnnotationWriter.java:198)
     at com.eed3si9n.jarjarabrams.scalasig.ScalaSigAnnotationVisitor.rewriteAnnotation(ScalaSigAnnotationVisitor.scala:91)
     at com.eed3si9n.jarjarabrams.scalasig.ScalaSigAnnotationVisitor.visitEnd(ScalaSigAnnotationVisitor.scala:47)
     at org.objectweb.asm.ClassReader.readElementValues(ClassReader.java:3003)
     at org.objectweb.asm.ClassReader.readElementValue(ClassReader.java:3173)
     at org.objectweb.asm.ClassReader.readElementValues(ClassReader.java:2993)
     at org.objectweb.asm.ClassReader.accept(ClassReader.java:608)
     at org.objectweb.asm.ClassReader.accept(ClassReader.java:424)
     at com.eed3si9n.jarjar.ScalaSigProcessor.process(ScalaSigProcessor.scala:15)
     at com.eed3si9n.jarjar.util.JarProcessorChain.process(JarProcessorChain.java:38)
     at com.eed3si9n.jarjar.JJProcessor.process(JJProcessor.scala:108)
     at com.eed3si9n.jarjarabrams.Shader$.$anonfun$bytecodeShader$6(Shader.scala:75)
     at com.eed3si9n.jarjarabrams.Shader$.$anonfun$shadeDirectory$4(Shader.scala:21
```
This PR extracts `nextChunk` to  standalone function, fixes the bug and adds a test for it. Unfortunately cannot include actual class causing error because it is from closed source project and there is no deterministic way to recreate it. 
