### PR TITLE
Do not remap inner class names

### DIFF
--- a/jarjar/src/main/java/com/eed3si9n/jarjar/PackageRemapper.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/PackageRemapper.java
@@ -117,6 +117,16 @@ class PackageRemapper extends Remapper
         }
     }
 
+    @Override
+    public String mapInnerClassName(
+            final String name, final String ownerName, final String innerName) {
+        // The default method would try to be smart and find the inner class name
+        // by looking at the $ sign. As the documentation calls out, this works in java
+        // but not necessarily in other languages, including scala, where $ has multiple applications.
+        // Since we actually don't care about remapping class names, only packages, we can ignore this
+        return innerName;
+    }
+
     private String replaceHelper(String value) {
         for (Wildcard wildcard : wildcards) {
             String test = wildcard.replace(value);

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/PackageRemapperTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/PackageRemapperTest.java
@@ -61,6 +61,13 @@ extends TestCase
       assertEquals("foo/example.package-info", remapper.mapValue("org/example.package-info"));
     }
 
+    @Test
+    public void testUnchangedInnerClassNames() {
+        String outer = "scala.collection.immutable.IntMap";
+        String inner = "Nil$";
+        assertEquals(inner, remapper.mapInnerClassName(outer + "$" + inner, outer, inner));
+    }
+
     private void assertUnchangedValue(String value) {
         assertEquals(value, remapper.mapValue(value));
     }


### PR DESCRIPTION
Prevent `PackageRemapper` from worgly remapping the inner class names due to wrong assumptions made by the `Remapper` class. The default implementation does not account for classes ending in `$`, which is the case for scala objects, causing the inner class name to be wiped.