### PR TITLE
upgrade ASM to 9.6 (was 9.5), for JDK 22 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,8 +27,8 @@ lazy val jarjar = project
     crossPaths := false
     autoScalaLibrary := false
     libraryDependencies ++= Seq(
-      "org.ow2.asm" % "asm" % "9.5",
-      "org.ow2.asm" % "asm-commons" % "9.5",
+      "org.ow2.asm" % "asm" % "9.6",
+      "org.ow2.asm" % "asm-commons" % "9.6",
       "org.apache.commons" % "commons-lang3" % "3.8.1",
       "junit" % "junit" % "4.12" % "it,test",
       "com.github.sbt" % "junit-interface" % "0.13.2" % "it,test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.9.7


### PR DESCRIPTION
this came up over at https://github.com/scala/community-build/issues/1698#issuecomment-1781279925

once there's a new jarjar-abrams, the next step would be a new sbt-assembly, which then we could use in the zinc build

but, no rush