### PR TITLE
Jarjar shouldn't mangle classes when no meaningful transformation applied

### DIFF
--- a/core/src/main/scala/com/eed3si9n/jarjar/JJProcessor.scala
+++ b/core/src/main/scala/com/eed3si9n/jarjar/JJProcessor.scala
@@ -52,7 +52,8 @@ class JJProcessor(
   processors += new ZapProcessor(zapList.asJava)
   processors += misplacedClassProcessor
   processors += new JarTransformerChain(
-    Array[RemappingClassTransformer](new RemappingClassTransformer()), pr
+    Array[RemappingClassTransformer](new RemappingClassTransformer()),
+    pr
   )
 
   val renamer: String => Option[String] = {

--- a/core/src/main/scala/com/eed3si9n/jarjar/JJProcessor.scala
+++ b/core/src/main/scala/com/eed3si9n/jarjar/JJProcessor.scala
@@ -52,7 +52,7 @@ class JJProcessor(
   processors += new ZapProcessor(zapList.asJava)
   processors += misplacedClassProcessor
   processors += new JarTransformerChain(
-    Array[RemappingClassTransformer](new RemappingClassTransformer(pr))
+    Array[RemappingClassTransformer](new RemappingClassTransformer()), pr
   )
 
   val renamer: String => Option[String] = {

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/MainProcessor.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/MainProcessor.java
@@ -74,8 +74,8 @@ class MainProcessor implements JarProcessor
         processors.add(new ZapProcessor(zapList));
         processors.add(misplacedClassProcessor);
         processors.add(new JarTransformerChain(new RemappingClassTransformer[] {
-            new RemappingClassTransformer(pr)
-        }));
+            new RemappingClassTransformer()
+        }, pr));
         processors.add(new MethodSignatureProcessor(pr));
         processors.add(new ResourceProcessor(pr));
         chain = new JarProcessorChain(processors.toArray(new JarProcessor[processors.size()]));

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/TracingRemapper.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/TracingRemapper.java
@@ -1,0 +1,15 @@
+package com.eed3si9n.jarjar;
+
+import org.objectweb.asm.commons.Remapper;
+
+public abstract class TracingRemapper extends Remapper {
+    /**
+     * Obtain the fresh copy of this object.
+     */
+    public abstract TracingRemapper copy();
+
+    /**
+     * Check if this instance remapped something already.
+     */
+    public abstract boolean hasChanges();
+}

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/util/EntryStruct.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/util/EntryStruct.java
@@ -21,4 +21,13 @@ public class EntryStruct {
     public String name;
     public long time;
     public boolean skipTransform;
+
+    public EntryStruct copy() {
+        EntryStruct result = new EntryStruct();
+        result.data = data;
+        result.name = name;
+        result.time = time;
+        result.skipTransform = skipTransform;
+        return result;
+    }
 }

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/util/JarTransformerChain.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/util/JarTransformerChain.java
@@ -31,8 +31,7 @@ public class JarTransformerChain extends JarTransformer
 
     protected ClassVisitor transform(ClassVisitor parent, Remapper remapper) {
         for (int i = chain.length - 1; i >= 0; i--) {
-            chain[i] = chain[i].update(remapper, parent);
-            parent = chain[i];
+            parent = chain[i].update(remapper, parent);
         }
         return parent;
     }

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/util/JarTransformerChain.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/util/JarTransformerChain.java
@@ -16,21 +16,24 @@
 
 package com.eed3si9n.jarjar.util;
 
+import com.eed3si9n.jarjar.TracingRemapper;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.commons.Remapper;
 
 public class JarTransformerChain extends JarTransformer
 {
     private final RemappingClassTransformer[] chain;
 
-    public JarTransformerChain(RemappingClassTransformer[] chain) {
+    public JarTransformerChain(RemappingClassTransformer[] chain, TracingRemapper remapper) {
+        super(remapper);
         this.chain = chain.clone();
-        for (int i = chain.length - 1; i > 0; i--) {
-            chain[i - 1].setTarget(chain[i]);
-        }
     }
 
-    protected ClassVisitor transform(ClassVisitor v) {
-        chain[chain.length - 1].setTarget(v);
-        return chain[0];
+    protected ClassVisitor transform(ClassVisitor parent, Remapper remapper) {
+        for (int i = chain.length - 1; i >= 0; i--) {
+            chain[i] = chain[i].update(remapper, parent);
+            parent = chain[i];
+        }
+        return parent;
     }
 }

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/util/RemappingClassTransformer.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/util/RemappingClassTransformer.java
@@ -24,11 +24,16 @@ import com.eed3si9n.jarjar.EmptyClassVisitor;
 
 public class RemappingClassTransformer extends ClassRemapper
 {
-    public RemappingClassTransformer(Remapper pr) {
-        super(new EmptyClassVisitor(), pr);
+    public RemappingClassTransformer() {
+        this(null, null);
     }
-        
-    public void setTarget(ClassVisitor target) {
-        cv = target;
+
+    public RemappingClassTransformer(Remapper pr, ClassVisitor parent) {
+        super(new EmptyClassVisitor(), pr);
+        this.cv = parent;
+    }
+
+    public RemappingClassTransformer update(Remapper pr, ClassVisitor target) {
+        return new RemappingClassTransformer(pr, target);
     }
 }

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/util/RemappingJarProcessor.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/util/RemappingJarProcessor.java
@@ -1,0 +1,41 @@
+package com.eed3si9n.jarjar.util;
+
+
+import com.eed3si9n.jarjar.TracingRemapper;
+import org.objectweb.asm.commons.Remapper;
+
+import java.io.IOException;
+
+/**
+ * Extension of JarProcessor for building processors around TracingRemapper.
+ *
+ * This class will track if TracingRemapper recorded doing any changes, and if it didn't,
+ * it will make sure that the underlying bytes are unmodified.
+ *
+ * This helps to avoid bytecode modifications when there was no actual changes
+ * to do.
+ */
+public abstract class RemappingJarProcessor implements JarProcessor {
+    private TracingRemapper remapper;
+
+    public RemappingJarProcessor(TracingRemapper remapper) {
+        this.remapper = remapper;
+    }
+
+    public final boolean process(EntryStruct struct) throws IOException {
+        TracingRemapper structRemapper = remapper.copy();
+        EntryStruct origStruct = struct.copy();
+
+        if (!processImpl(struct, structRemapper)) {
+            return false;
+        }
+
+        if (!structRemapper.hasChanges()) {
+            struct.data = origStruct.data;
+        }
+
+        return true;
+    }
+
+    protected abstract boolean processImpl(EntryStruct struct, Remapper remapper) throws IOException;
+}

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/GenericsTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/GenericsTest.java
@@ -32,8 +32,9 @@ extends TestCase
          Rule rule = new Rule();
          rule.setPattern("java.lang.String");
          rule.setResult("com.tonicsystems.String");
-         RemappingClassTransformer t = new RemappingClassTransformer(new PackageRemapper(Arrays.asList(rule), false));
-         t.setTarget(new EmptyClassVisitor());
+         RemappingClassTransformer t = new RemappingClassTransformer(
+                 new PackageRemapper(Arrays.asList(rule), false), new EmptyClassVisitor()
+         );
          ClassReader reader = new ClassReader(getClass().getResourceAsStream("/Generics.class"));
          reader.accept(t, 0);
     }

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/MethodRewriterTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/MethodRewriterTest.java
@@ -46,7 +46,7 @@ public class MethodRewriterTest extends TestCase {
     }
   }
 
-  private static byte[] readInputStream(InputStream inputStream) throws IOException {
+  protected static byte[] readInputStream(InputStream inputStream) throws IOException {
     byte[] buf = new byte[0x2000];
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     IoUtil.pipe(inputStream, baos, buf);

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/UnmodifiedTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/UnmodifiedTest.java
@@ -1,0 +1,35 @@
+package com.eed3si9n.jarjar;
+
+import com.eed3si9n.jarjar.util.EntryStruct;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.eed3si9n.jarjar.MethodRewriterTest.readInputStream;
+
+public class UnmodifiedTest {
+    @Test
+    public void testNotModified() throws Exception {
+        Rule rule = new Rule();
+        rule.setPattern("com.abc");
+        rule.setResult("com.def");
+
+        MainProcessor mp = new MainProcessor(Arrays.asList(rule), false, false, "move");
+
+        EntryStruct entryStruct = new EntryStruct();
+        entryStruct.name = "BigtableIO$Write.class";
+        entryStruct.skipTransform = false;
+        entryStruct.time = 0;
+        entryStruct.data =
+                readInputStream(
+                        getClass().getResourceAsStream("/com/eed3si9n/jarjar/BigtableIO$Write.class"));
+
+        EntryStruct orig = entryStruct.copy();
+
+        mp.process(entryStruct);
+
+        Assert.assertEquals(entryStruct.data, orig.data);
+    }
+}

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/VersionedClassTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/VersionedClassTest.java
@@ -9,6 +9,7 @@ import junit.framework.TestCase;
 import org.junit.Test;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.commons.ClassRemapper;
+import org.objectweb.asm.commons.Remapper;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -37,13 +38,15 @@ extends TestCase
         String expectedName = Example.class.getName().replace("jarjar", "jarjarabrams");
         struct.name = MisplacedClassProcessor.VERSIONED_CLASS_FOLDER + "9/" + toClassPath(originalName);
         struct.data = getClassBytes(originalName);
-        JarTransformer transformer = new JarTransformer() {
+
+        Rule rule = new Rule();
+        rule.setPattern(originalName);
+        rule.setResult(expectedName);
+        PackageRemapper remapper = new PackageRemapper(Arrays.asList(rule), false);
+
+        JarTransformer transformer = new JarTransformer(remapper) {
             @Override
-            protected ClassVisitor transform(ClassVisitor v) {
-                Rule rule = new Rule();
-                rule.setPattern(originalName);
-                rule.setResult(expectedName);
-                PackageRemapper remapper = new PackageRemapper(Arrays.asList(rule), false);
+            protected ClassVisitor transform(ClassVisitor v, Remapper remapper) {
                 return new ClassRemapper(v, remapper);
             }
         };


### PR DESCRIPTION
In case big module and all it dependent jars are going through jarjar shading, there will probably be dependent jars which are not actually modified by shading.

However because they go through jarjar, it unpacks, revisits, and repacks the class back resulting a technically different class from before shading (even class size can be different from original). This upsets classpath checkers (i.e. checking that runtime classpath has at most 1 unique class version).

I propose to add a change so that jarjar can detect whether the meaningful transformation to class file has happened and if not, the class is unmodified.

This pull request introduces following new concepts:
* TracingRemapper: extension of Remapper with capability of tracking if the change was applied;
* RemappingJarProcessor: extension of JarProcessor focusing on TracingRemapper-based processors. It assumes ownership of TracingRemapper, and will verify if the mentioned remapper did any transformation.

The existing classes change as follows:
* PackageRemapper: becomes instance of TracingRemapper.
* JarTransformer, MethodSignatureProcessor: become instance of RemappingJarProcessor.
* JarTransformerChain: instead of being stateful class keeping track of parent visitors, becomes stateless class. This potentially allows multi-threaded processing and better design overall.

Added coverage for the proposed new functionality in UnmodifiedTest.

Closes: #47