### PR TITLE
Modified Zap so that it removes matched resources

### DIFF
--- a/jarjar/src/main/java/com/eed3si9n/jarjar/ZapProcessor.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/ZapProcessor.java
@@ -30,9 +30,20 @@ class ZapProcessor implements JarProcessor
 
     public boolean process(EntryStruct struct) throws IOException {
         String name = struct.name;
-        if (name.endsWith(".class"))
-            return !zap(name.substring(0, name.length() - 6));
-        return true;
+        String matchName = name.endsWith(".class") ?
+                name.substring(0, name.length() - 6) :
+                replaceResourceName(name);
+        return !zap(matchName);
+    }
+
+    private static final String RESOURCE_SUFFIX = "RESOURCE";
+
+    private static String replaceResourceName(String name) {
+        int slash = name.lastIndexOf('/');
+
+        String s = (slash < 0) ? RESOURCE_SUFFIX : name.substring(0, slash + 1) + RESOURCE_SUFFIX;
+        boolean absolute = s.startsWith("/");
+        return absolute ? s.substring(1) : s;
     }
     
     private boolean zap(String desc) {

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/ZapProcessorTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/ZapProcessorTest.java
@@ -22,6 +22,12 @@ public class ZapProcessorTest
 
     entryStruct.name = "com/example/Object.class";
     assertTrue(zapProcessor.process(entryStruct));
+
+    entryStruct.name = "org/file.txt";
+    assertFalse(zapProcessor.process(entryStruct));
+
+    entryStruct.name = "com/file.txt";
+    assertTrue(zapProcessor.process(entryStruct));
   }
 
   @Test


### PR DESCRIPTION
Modified Zap so that it removes matched resources in addition to class files. (Issue #48)

The matching of resources targets their path, excluding their filename, using the same logic used for Rule (see PackageRemapper.mapPath()).