### PR TITLE
Unify to newline character

### DIFF
--- a/jarjar/src/main/java/com/eed3si9n/jarjar/ResourceProcessor.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/ResourceProcessor.java
@@ -58,9 +58,9 @@ class ResourceProcessor implements JarProcessor
         // The file can also have comments and whitespaces
         String s = new String(providers, StandardCharsets.UTF_8);
 
-        String mapped = Arrays.stream(s.split(System.lineSeparator()))
+        String mapped = Arrays.stream(s.split("\n"))
             .map(l -> (String) pr.mapValue(Arrays.stream(l.split("#")).findFirst().orElse("").trim()))
-            .collect(Collectors.joining(System.lineSeparator()));
+            .collect(Collectors.joining("\n")) + "\n";
         return mapped.getBytes(StandardCharsets.UTF_8);
     }
 

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/ResourceProcessorTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/ResourceProcessorTest.java
@@ -34,16 +34,16 @@ public class ResourceProcessorTest {
 
     @Test
     public void testServiceProviderConfig() throws IOException {
-        String original = "org.example.Impl     # comment" + System.lineSeparator()
-                        + "org.example.AnotherImpl" + System.lineSeparator()
-                        + "#" + System.lineSeparator()
-                        + System.lineSeparator()
+        String original = "org.example.Impl     # comment\n"
+                        + "org.example.AnotherImpl\n"
+                        + "#\n"
+                        + "\n"
                         + "     org.another.Impl";
-        String expected = "something.shaded.org.example.Impl" + System.lineSeparator()
-                        + "something.shaded.org.example.AnotherImpl" + System.lineSeparator()
-                        + System.lineSeparator()
-                        + System.lineSeparator()
-                        + "org.another.Impl";
+        String expected = "something.shaded.org.example.Impl\n"
+                        + "something.shaded.org.example.AnotherImpl\n"
+                        + "\n"
+                        + "\n"
+                        + "org.another.Impl\n";
         EntryStruct entryStruct = new EntryStruct();
         entryStruct.name = "META-INF/services/org.example.Service";
         entryStruct.data = original.getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
Ref https://github.com/eed3si9n/jarjar-abrams/issues/60

## Problem
There's a report of service loader configuration getting dropped by jarjar, which apparently started in 1.8.1.
I personally could not reproduce this behavior, but maybe this has something to do with `\n` vs `System.lineSeparator()`, which on Windows will be `\r\n`.

## Solution
This unifies the resource file rewrite to use `\n`.
