### PR TITLE
Escape $ in patterns

### DIFF
--- a/jarjar/src/main/java/com/eed3si9n/jarjar/Wildcard.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/Wildcard.java
@@ -26,6 +26,7 @@ class Wildcard
     private static Pattern dstar = Pattern.compile("\\*\\*");
     private static Pattern star  = Pattern.compile("\\*");
     private static Pattern estar = Pattern.compile("\\+\\??\\)\\Z");
+    private static Pattern dollar  = Pattern.compile("\\$");
 
     private final Pattern pattern;
     private final int count;
@@ -45,6 +46,7 @@ class Wildcard
         regex = replaceAllLiteral(dstar, regex, "(.+?)");
         regex = replaceAllLiteral(star, regex, "([^/]+)");
         regex = replaceAllLiteral(estar, regex, "*)");
+        regex = replaceAllLiteral(dollar, regex, "\\$");
         this.pattern = Pattern.compile("\\A" + regex + "\\Z");
         this.count = this.pattern.matcher("foo").groupCount();
 


### PR DESCRIPTION
`$` is a valid character in an identifier (`Character.isJavaIdentifierPart`) and thus it is (correctly) accepted by jarjar in rule patterns, but it is not escaped when building the regex (which is not necessary for other identifier characters). This makes it impossible to match inner classes (which always contain a `$`) and other synthetic classes directly (which is necessary to rename classes instead of simply moving them to other packages). Escaping it as `\$` makes these matches work correctly.