### PR TITLE
Fix EntryTable.renameEntries to Respect Shading Rules Deterministically

### DIFF
--- a/core/src/main/scala/com/eed3si9n/jarjarabrams/scalasig/EntryTable.scala
+++ b/core/src/main/scala/com/eed3si9n/jarjarabrams/scalasig/EntryTable.scala
@@ -37,19 +37,34 @@ class EntryTable(majorVersion: Int, minorVersion: Int, entries: mutable.Buffer[T
    */
   def renameEntries(renamer: String => Option[String]): Unit = {
 
-    entries.zipWithIndex.collect {
-      case (ref: RefEntry, index) =>
-        entries(ref.nameRef) match {
-          case nameEntry: NameEntry =>
-            for {
-              fqName <- resolveRef(ref)
-              renamed <- renamer(fqName)
-            } {
+    entries.zipWithIndex
+      .collect {
+        case (ref: RefEntry, index) =>
+          entries(ref.nameRef) match {
+            case nameEntry: NameEntry =>
+              resolveRef(ref).map { (_, (ref, nameEntry, index)) }
+
+            case other =>
+              throw new RuntimeException(
+                s"Ref entry does not point to a name but to a ${other.tag}"
+              )
+          }
+      }
+      .flatten
+      .sortBy(_._1)
+      .foreach {
+        case (fqName, (ref, nameEntry, index)) =>
+          val renameResult = renamer(fqName)
+          val curName = resolveRef(ref)
+
+          for (renamed <- renameResult) {
+            if (!curName.contains(renamed)) {
               val parts = renamed.split('.')
 
               val myOwner = parts.init.foldLeft(Option.empty[Int]) { (owner, part) =>
                 val nameIndex = getOrAppendNameEntry(NameEntry(PickleFormat.TERMname, part))
-                val nextOwner = appendEntry(RefEntry(PickleFormat.EXTMODCLASSref, nameIndex, owner))
+                val nextOwner =
+                  appendEntry(RefEntry(PickleFormat.EXTMODCLASSref, nameIndex, owner))
                 Some(nextOwner)
               }
 
@@ -58,11 +73,8 @@ class EntryTable(majorVersion: Int, minorVersion: Int, entries: mutable.Buffer[T
                 ownerRef = myOwner
               )
             }
-
-          case other =>
-            throw new RuntimeException(s"Ref entry does not point to a name but to a ${other.tag}")
-        }
-    }
+          }
+      }
   }
 
   // Return existing name entry or append a new one.


### PR DESCRIPTION
**Short description:** Make renameEntries deterministic — process refs by package-prefix order and match rules against original fully qualified names to honor shading precedence.

Full description below.

---

## 1 · Background – what a *ScalaSignature* is

Scala embeds a compressed *symbol table* in every class file via the `@scala.reflect.ScalaSignature` annotation.  It records each identifier name, owner chain, and type so that:

- the compiler can perform separate compilation, and
- reflection libraries can reconstruct Scala‑specific details.

A fully‑qualified package path like `com.example.testpkg` is stored as a linked chain of external reference (​`Ref`​) entries:

```
Ref("testpkg", owner = Ref("example", owner = Ref("com", owner = None)))
```

Any shading tool must therefore update both byte‑code **and** these refs; otherwise reflection and downstream compilation will break.


## 2 · Problem – current algorithm is order‑dependent

The user supplies **two rename rules**

```
1. com.example.testpkg → other
2. com → shade.com
```

Per sbt‑assembly’s contract, rule 1 should always win for the class `com.example.testpkg.Foo`, and rule 2 should apply to everything else under `com`.

`EntryTable.renameEntries`, however, walks the *pickled reference DAG* in whatever order those refs happen to appear.  Because the walk mutates the FQN *before* the matcher is called, the outcome depends on **which ref is visited first**:

| Tree‑walk order (parent ⇢ child) | Expected result                             | Actual result today                                                                                                                                                                              |
| -------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `com` → `com.example.testpkg`    | `Foo` ends up in `other.Foo` (rule 1 wins). | **Wrong.** Visiting `com` first rewrites the owner chain to `shade.com.…`; by the time we reach `com.example.testpkg` the matcher sees `shade.com.example.testpkg` and rule 1 no longer matches. |
| `com.example.testpkg` → `com`    | Same: `Foo` in `other.Foo`                  | **Works *****by luck*****.** Because the child ref is processed first, rule 1 fires before the parent changes its owner chain.                                                                   |

Thus two *identical* compilations can yield different shaded artifacts, violating determinism and the *“first rule wins”* guarantee.


## 3 · Proposed fix

1. **Sort refs by prefix length** – process `com` ➔ `com.example` ➔ `com.example.testpkg`.  Parents are always handled before children.
2. **Match against the *****original***** FQN** – cache each ref’s pristine name before any mutations and pass that to the matcher.  Rules never see partially shaded paths.
3. **Apply at most one rule** (first match wins) – aligns exactly with sbt‑assembly’s spec.

The implementation appends new `NameEntry`/`RefEntry` objects so existing indices remain valid.


## 4 · Why this change is necessary

- **Determinism** – output no longer depends on random pickle order.
- **Spec compliance** – rule precedence is governed solely by the user’s rule list.
- **Soundness** – prevents mixed paths that break reflection and incremental compilation.


## 5 · Testing

- Verifies both rule orders produce the same, correct result.
- All existing tests remain green.
