### PR TITLE
Zip multithreading and single write pass

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,6 +113,10 @@ lazy val core = project
       if (scalaVersion.value.startsWith("2.10.")) Nil
       else Vector(verify % Test)
     }
+    libraryDependencies ++= {
+      if (scalaVersion.value.startsWith("2.13.")) Vector(parallel)
+      else Nil
+    }
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value
 
     Compile / managedSourceDirectories += (Compile / generateContrabands / sourceManaged).value

--- a/core/src/main/scala/com/eed3si9n/jarjarabrams/Zip.scala
+++ b/core/src/main/scala/com/eed3si9n/jarjarabrams/Zip.scala
@@ -1,16 +1,33 @@
 package com.eed3si9n.jarjarabrams
 
-import com.eed3si9n.jarjar.util.{ DuplicateJarEntryException, EntryStruct, IoUtil }
+import com.eed3si9n.jarjar.util.{ DuplicateJarEntryException, EntryStruct }
 import java.nio.file.{ Files, NoSuchFileException, Path }
 import java.nio.file.attribute.FileTime
 import java.io.{ ByteArrayOutputStream, FileNotFoundException, InputStream, OutputStream }
 import java.security.MessageDigest
 import java.util.jar.JarEntry
-import scala.annotation.tailrec
+import scala.annotation.{ nowarn, tailrec }
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
+@nowarn("msg=Unused import")
 object Zip {
+  private object ParCollectionCrossBuild {
+    object Default {
+      object CollectionConverters
+    }
+
+    val Converters = {
+      import Default._
+      {
+        import scala.collection.parallel._
+        CollectionConverters
+      }
+    }
+
+  }
+
+  import ParCollectionCrossBuild.Converters._
 
   /** The size of the byte or char buffer used in various methods. */
   private final val BufferSize = 8192
@@ -50,40 +67,70 @@ object Zip {
       warnOnDuplicateClass: Boolean
   )(f: EntryStruct => Option[EntryStruct]): Path =
     Using.jarFile(inputJar) { in =>
-      val tempJar = Files.createTempFile("jarjar", ".jar")
-      Using.jarOutputStream(tempJar) { out =>
+      Using.jarOutputStream(outputJar) { out =>
         val names = new mutable.HashSet[String]
-        in.entries.asScala.foreach { entry0 =>
-          val struct0 = entryStruct(
-            entry0.getName,
-            entry0.getTime,
-            toByteArray(in.getInputStream(entry0)),
-            skipTransform = false
-          )
-          f(struct0) match {
-            case Some(struct) =>
-              if (names.add(struct.name)) {
-                val entry = new JarEntry(struct.name)
-                val time =
-                  if (resetTimestamp) hardcodedZipTimestamp(struct.name)
-                  else enforceMinimum(struct.time)
-                entry.setTime(time)
-                entry.setCompressedSize(-1)
-                out.putNextEntry(entry)
-                out.write(struct.data)
-              } else if (struct.name.endsWith("/")) ()
-              else {
-                if (warnOnDuplicateClass)
-                  Console.err.println(
-                    s"in ${inputJar}, found duplicate files with name: ${struct.name}, ignoring due to specified option"
-                  )
-                else throw new DuplicateJarEntryException(inputJar.toString, struct.name)
+        val structsIter = in.entries.asScala
+          .grouped(100000)
+          .flatMap(_.par.flatMap { entry0 =>
+            val struct0 = entryStruct(
+              entry0.getName,
+              entry0.getTime,
+              toByteArray(in.getInputStream(entry0)),
+              skipTransform = false
+            )
+            f(struct0)
+          }.toIterator)
+          .filter { struct =>
+            if (names.add(struct.name)) {
+              true
+            } else if (struct.name.endsWith("/")) {
+              false
+            } else if (warnOnDuplicateClass) {
+              Console.err.println(
+                s"in ${inputJar}, found duplicate files with name: ${struct.name}, ignoring due to specified option"
+              )
+              false
+            } else throw new DuplicateJarEntryException(inputJar.toString, struct.name)
+          }
+
+        val dirsToRetain = mutable.HashSet.empty[String]
+        val undecidedDirs = mutable.HashMap.empty[String, EntryStruct]
+
+        def outputStruct(struct: EntryStruct): Unit = {
+          val entry = new JarEntry(struct.name)
+          val time =
+            if (resetTimestamp) hardcodedZipTimestamp(struct.name)
+            else enforceMinimum(struct.time)
+          entry.isDirectory
+          entry.setTime(time)
+          entry.setCompressedSize(-1)
+          out.putNextEntry(entry)
+          out.write(struct.data)
+        }
+
+        structsIter.foreach { struct =>
+          val name = struct.name
+          if (name.endsWith("/")) {
+            if (dirsToRetain(name)) {
+              outputStruct(struct)
+            } else {
+              undecidedDirs(name) = struct
+            }
+          } else {
+            val directory = name.substring(0, name.lastIndexOf('/') + 1)
+            var index = 0
+            while (index != directory.length) {
+              index = directory.indexOf('/', index) + 1
+              val dirName = directory.substring(0, index)
+              if (dirsToRetain.add(dirName)) {
+                undecidedDirs.remove(dirName).foreach(outputStruct)
               }
-            case None => ()
+            }
+
+            outputStruct(struct)
           }
         }
       }
-      IoUtil.copyZipWithoutEmptyDirectories(tempJar.toFile, outputJar.toFile)
       resetModifiedTime(outputJar)
       outputJar
     }

--- a/core/src/test/scala/testpkg/ShaderTest.scala
+++ b/core/src/test/scala/testpkg/ShaderTest.scala
@@ -15,7 +15,7 @@ object ShaderTest extends BasicTestSuite {
       Paths.get(byteBuddyJar),
       resetTimestamp = false,
       expectedClass = expectedByteBuddyClass,
-      expectedSha = "42454701a0b53a13af17d015c1785ef5ea342d8c324315ed17d80831cba98be3"
+      expectedSha = "f3f441dd5ab28577083ab4e5235382db76fb9b60b7117a712691f0e25ab2cea4"
     )
   }
 
@@ -24,7 +24,7 @@ object ShaderTest extends BasicTestSuite {
       Paths.get(byteBuddyJar),
       resetTimestamp = true,
       expectedClass = expectedByteBuddyClass,
-      expectedSha = "0db0b1300533c06a934dca1e7016f6dc2d432c66f1927102d6f6b49086dcfddb"
+      expectedSha = "debbc6e00c39c1ad50f238055696538d98faf59458d10845154c4fb87234eddc"
     )
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,4 +6,5 @@ object Dependencies {
   val scala212 = "2.12.18"
   val scala213 = "2.13.12"
   val verify = "com.eed3si9n.verify" %% "verify" % "0.2.0"
+  val parallel = "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.2"
 }


### PR DESCRIPTION
For large jar files (2 gb) the process became slow (>6min). I changed two things to improve performance:

1. For CPU utilisation, most of the time is spent in function `f: EntryStruct => Option[EntryStruct]` that is pure and therefore embarrassingly parallel. I used build in scala parallel collections for this.

2. `Using.jarFile(inputJar); Using.jarOutputStream(outputJar)` and `IoUtil.copyZipWithoutEmptyDirectories(tempJar.toFile, outputJar.toFile)` both read and write the whole file. I merged it into single read and write.


For my problem this improved execution time from 6 min to 2:30 min