### PR TITLE
Fixed HashMap concurrency problem

### DIFF
--- a/jarjar/src/main/java/com/eed3si9n/jarjar/KeepProcessor.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/KeepProcessor.java
@@ -28,7 +28,7 @@ class KeepProcessor extends Remapper implements JarProcessor
     private final ClassVisitor cv = new ClassRemapper(new EmptyClassVisitor(), this);
     private final List<Wildcard> wildcards;
     private final List<String> roots = new ArrayList<String>();
-    private final Map<String, Set<String>> depend = new HashMap<String, Set<String>>();
+    private final Map<String, Set<String>> depend = Collections.synchronizedMap(new HashMap<>());
 
     public KeepProcessor(List<Keep> patterns) {
         wildcards = PatternElement.createWildcards(patterns);

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/PackageRemapper.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/PackageRemapper.java
@@ -30,9 +30,9 @@ class PackageRemapper extends TracingRemapper
 
     private final List<Wildcard> wildcards;
     private final List<Rule> ruleList;
-    private final Map<String, String> typeCache = new HashMap<String, String>();
-    private final Map<String, String> pathCache = new HashMap<String, String>();
-    private final Map<Object, String> valueCache = new HashMap<Object, String>();
+    private final Map<String, String> typeCache = Collections.synchronizedMap(new HashMap<>());
+    private final Map<String, String> pathCache = Collections.synchronizedMap(new HashMap<>());
+    private final Map<Object, String> valueCache = Collections.synchronizedMap(new HashMap<>());
     private final boolean verbose;
     private boolean modified = false;
 


### PR DESCRIPTION
Missed them when I added concurrency, we are getting errors like:

```
[2025-09-10T17:52:55Z] Exception in thread "main" java.lang.ClassCastException: class java.util.HashMap$Node cannot be cast to class java.util.HashMap$TreeNode (java.util.HashMap$Node and java.util.HashMap$TreeNode are in module java.base of loader 'bootstrap')
[2025-09-10T17:52:55Z] 	at java.base/java.util.HashMap$TreeNode.moveRootToFront(HashMap.java:1994)
[2025-09-10T17:52:55Z] 	at java.base/java.util.HashMap$TreeNode.treeify(HashMap.java:2110)
[2025-09-10T17:52:55Z] 	at java.base/java.util.HashMap.treeifyBin(HashMap.java:778)
[2025-09-10T17:52:55Z] 	at java.base/java.util.HashMap.putVal(HashMap.java:650)
[2025-09-10T17:52:55Z] 	at java.base/java.util.HashMap.put(HashMap.java:618)
[2025-09-10T17:52:55Z] 	at com.eed3si9n.jarjar.PackageRemapper.mapPath(PackageRemapper.java:89)
[2025-09-10T17:52:55Z] 	at com.eed3si9n.jarjar.ResourceProcessor.process(ResourceProcessor.java:45)
[2025-09-10T17:52:55Z] 	at com.eed3si9n.jarjar.util.JarProcessorChain.process(JarProcessorChain.java:38)
[2025-09-10T17:52:55Z] 	at com.eed3si9n.jarjar.JJProcessor.process(JJProcessor.scala:109)
[2025-09-10T17:52:55Z] 	at com.eed3si9n.jarjarabrams.Shader$.$anonfun$bytecodeShader$6(Shader.scala:120)
[2025-09-10T17:52:55Z] 	at com.eed3si9n.jarjarabrams.Shader$.$anonfun$shadeFile$1(Shader.scala:21)
```