### PR TITLE
avoid deprecated `java.lang.Integer` constructor

### DIFF
--- a/jarjar/src/main/java/com/eed3si9n/jarjar/Wildcard.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/Wildcard.java
@@ -70,7 +70,7 @@ class Wildcard
                     int n = Integer.parseInt(new String(chars, mark, i - mark));
                     if (n > max)
                         max = n;
-                    parts.add(new Integer(n));
+                    parts.add(Integer.valueOf(n));
                     mark = i--;
                     state = 0;
                 }


### PR DESCRIPTION
https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Integer.html#%3Cinit%3E(int)