### PR TITLE
Bug fixes: incorrect `keep` directive, race condition, and improve logging

### DIFF
--- a/core/src/main/scala/com/eed3si9n/jarjar/JJProcessor.scala
+++ b/core/src/main/scala/com/eed3si9n/jarjar/JJProcessor.scala
@@ -116,6 +116,10 @@ class JJProcessor(
           System.err.println(s"Skipped $name without processing because $name == ${struct.name}")
         }
       }
+    } else {
+      if (verbose) {
+        System.err.println(s"Removed $name due to chain rejection")
+      }
     }
     keepIt
   }

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/DepFind.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/DepFind.java
@@ -44,7 +44,8 @@ public class DepFind
                   header.read(in);
                   classes.put(header.getClassName(), entry.getSource());
                 } catch (Exception e) {
-                  System.err.println("Error reading " + entry.getName() + ": " + e.getMessage());
+                  System.err.println("[DepFind] Error reading " + entry.getName() + ": " + e.getMessage());
+                  e.printStackTrace(System.err);
                 } finally {
                   in.close();
                 }
@@ -64,7 +65,8 @@ public class DepFind
                       new DepFindVisitor(classes, entry.getSource(), handler),
                       ClassReader.SKIP_DEBUG);
                 } catch (Exception e) {
-                  System.err.println("Error reading " + entry.getName() + ": " + e.getMessage());
+                  System.err.println("[DepFind] Error reading " + entry.getName() + ": " + e.getMessage());
+                  e.printStackTrace(System.err);
                 } finally {
                   in.close();
                 }

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/KeepProcessor.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/KeepProcessor.java
@@ -56,16 +56,25 @@ class KeepProcessor extends Remapper implements JarProcessor
         }
     }
 
+    private final Object csdMutex = new Object();
     private Set<String> currentDependenciesSet;
 
     public boolean process(EntryStruct struct) throws IOException {
         if (struct.name.endsWith(".class")) {
             String name = struct.name.substring(0, struct.name.length() - 6);
-            depend.put(name, currentDependenciesSet = new HashSet<String>());
+
+            synchronized (csdMutex) {
+                currentDependenciesSet = new HashSet<String>();
+                depend.put(name, currentDependenciesSet);
+            }
+
             try {
                 new ClassReader(new ByteArrayInputStream(struct.data)).accept(cv,
                         ClassReader.EXPAND_FRAMES);
-                currentDependenciesSet.remove(name);
+
+                synchronized (csdMutex) {
+                    currentDependenciesSet.remove(name);
+                }
             } catch (Exception e) {
                 System.err.println("[KeepProcessor] Error reading " + struct.name + ": " + e.getMessage());
                 e.printStackTrace(System.err);
@@ -84,7 +93,9 @@ class KeepProcessor extends Remapper implements JarProcessor
     public String map(String key) {
         if (key.startsWith("java/") || key.startsWith("javax/"))
             return null;
-        currentDependenciesSet.add(key);
+        synchronized (csdMutex) {
+            currentDependenciesSet.add(key);
+        }
         return null;
     }
 

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/KeepProcessor.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/KeepProcessor.java
@@ -67,7 +67,8 @@ class KeepProcessor extends Remapper implements JarProcessor
                         ClassReader.EXPAND_FRAMES);
                 currentDependenciesSet.remove(name);
             } catch (Exception e) {
-                System.err.println("Error reading " + struct.name + ": " + e.getMessage());
+                System.err.println("[KeepProcessor] Error reading " + struct.name + ": " + e.getMessage());
+                e.printStackTrace(System.err);
             }
 
             for (Wildcard wildcard : wildcards) {

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/KeepProcessor.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/KeepProcessor.java
@@ -73,10 +73,9 @@ class KeepProcessor extends Remapper implements JarProcessor
             for (Wildcard wildcard : wildcards) {
                 if (wildcard.matches(name)) {
                     roots.add(name);
-                    return true;
+                    break;
                 }
             }
-            return false;
         }
         return true;
     }

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/StringDumper.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/StringDumper.java
@@ -35,7 +35,8 @@ class StringDumper
                 try {
                     new ClassReader(in).accept(stringReader, 0);
                 } catch (Exception e) {
-                    System.err.println("Error reading " + entry.getName() + ": " + e.getMessage());
+                    System.err.println("[StringDumper] Error reading " + entry.getName() + ": " + e.getMessage());
+                    e.printStackTrace(System.err);
                 } finally {
                     in.close();
                 }

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/KeepProcessorTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/KeepProcessorTest.java
@@ -21,7 +21,10 @@ public class KeepProcessorTest
         assertTrue(keepProcessor.process(entryStruct));
 
         entryStruct.name = "com/example/Object.class";
-        assertFalse(keepProcessor.process(entryStruct));
+        assertTrue(keepProcessor.process(entryStruct));
+
+        assertFalse(keepProcessor.getExcludes().contains("org/example/Object"));
+        assertTrue(keepProcessor.getExcludes().contains("com/example/Object"));
     }
 
     @Test
@@ -35,6 +38,9 @@ public class KeepProcessorTest
         assertTrue(keepProcessor.process(entryStruct));
 
         entryStruct.name = "META-INF/versions/8/com/example/Object.class";
-        assertFalse(keepProcessor.process(entryStruct));
+        assertTrue(keepProcessor.process(entryStruct));
+
+        assertFalse(keepProcessor.getExcludes().contains("META-INF/versions/9/org/example/Object"));
+        assertTrue(keepProcessor.getExcludes().contains("META-INF/versions/8/com/example/Object"));
     }
 }


### PR DESCRIPTION
tl;dr: Fixes a set of bugs we encountered when attempting to update to the latest version internally. Also added some additional logging that was useful when debugging jarjar in Bazel.

## 1) Incorrect `keep` directive
As mentioned in https://github.com/eed3si9n/jarjar-abrams/issues/55, the `keep` directive is not correctly including the transitive deps of a class. Due to the added `return false;` in `KeepProcessor#process`, any class that did not **explicitly match** the keep pattern would be removed from the final jar. This differs from the original _expected_ behavior which collects the final class exclusion via the `getExcludes` method to be removed after processing rather than during.

To fix this, I've removed the `return false`. (And for readability, replaced the `return true` in the pattern loop with a `break`.

## 2) Race condition
Stacktrace:
```
[KeepProcessor] Error reading scala/collection/mutable/ArrayOps$ofLong.class: Cannot invoke "java.util.HashMap.put(Object, Object)" because "this.map" is null
java.lang.NullPointerException: Cannot invoke "java.util.HashMap.put(Object, Object)" because "this.map" is null
        at java.base/java.util.HashSet.add(HashSet.java:221)
        at com.eed3si9n.jarjar.KeepProcessor.map(KeepProcessor.java:87)
        at org.objectweb.asm.commons.Remapper.mapType(Remapper.java:127)
        at org.objectweb.asm.commons.Remapper.mapDesc(Remapper.java:104)
        at org.objectweb.asm.commons.MethodRemapper.visitLocalVariable(MethodRemapper.java:249)
        at org.objectweb.asm.ClassReader.readCode(ClassReader.java:2593)
        at org.objectweb.asm.ClassReader.readMethod(ClassReader.java:1512)
        at org.objectweb.asm.ClassReader.accept(ClassReader.java:745)
        at org.objectweb.asm.ClassReader.accept(ClassReader.java:425)
        at com.eed3si9n.jarjar.KeepProcessor.process(KeepProcessor.java:66)
        at com.eed3si9n.jarjar.util.JarProcessorChain.process(JarProcessorChain.java:38)
        at com.eed3si9n.jarjar.JJProcessor.process(JJProcessor.scala:109)
        at com.eed3si9n.jarjarabrams.Shader$.$anonfun$bytecodeShader$6(Shader.scala:118)
        at com.eed3si9n.jarjarabrams.Shader$.$anonfun$shadeFile$1(Shader.scala:21)
        at com.eed3si9n.jarjarabrams.Zip$.$anonfun$transformJarFile$4(Zip.scala:83)
        at scala.collection.parallel.AugmentedIterableIterator.flatmap2combiner(RemainsIterator.scala:133)
        at scala.collection.parallel.AugmentedIterableIterator.flatmap2combiner$(RemainsIterator.scala:130)
        at scala.collection.parallel.immutable.ParVector$ParVectorIterator.flatmap2combiner(ParVector.scala:66)
        at scala.collection.parallel.ParIterableLike$FlatMap.leaf(ParIterableLike.scala:1082)
        at scala.collection.parallel.Task.$anonfun$tryLeaf$1(Tasks.scala:53)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at scala.util.control.Breaks$$anon$1.catchBreak(Breaks.scala:67)
        at scala.collection.parallel.Task.tryLeaf(Tasks.scala:56)
        at scala.collection.parallel.Task.tryLeaf$(Tasks.scala:50)
        at scala.collection.parallel.ParIterableLike$FlatMap.tryLeaf(ParIterableLike.scala:1078)
        at scala.collection.parallel.AdaptiveWorkStealingTasks$WrappedTask.internal(Tasks.scala:160)
        at scala.collection.parallel.AdaptiveWorkStealingTasks$WrappedTask.internal$(Tasks.scala:157)
        at scala.collection.parallel.AdaptiveWorkStealingForkJoinTasks$WrappedTask.internal(Tasks.scala:440)
        at scala.collection.parallel.AdaptiveWorkStealingTasks$WrappedTask.compute(Tasks.scala:150)
        at scala.collection.parallel.AdaptiveWorkStealingTasks$WrappedTask.compute$(Tasks.scala:149)
        at scala.collection.parallel.AdaptiveWorkStealingForkJoinTasks$WrappedTask.compute(Tasks.scala:440)
        at java.base/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```

The only possible way that the backing map for a HashSet can be null is if it is accessed before its `init` updates the `map` reference. To fix this, I have simply wrapped the assignment and accesses of `currentDependenciesSet` using a Mutex. (This error was surfaced from the logging changes as well.)

Let me know if you would like anything changed!