### PR TITLE
Re-emit ScalaInlineInfo when shading

### DIFF
--- a/core/src/test/scala/testpkg/ShaderTest.scala
+++ b/core/src/test/scala/testpkg/ShaderTest.scala
@@ -33,7 +33,7 @@ object ShaderTest extends BasicTestSuite {
       Paths.get(shapelessJar),
       resetTimestamp = false,
       expectedClass = expectedShapelessClass,
-      expectedSha = "b0675ab6b2171faad08de45ccbc4674df569e03b434745ebd9e7442cd7846796"
+      expectedSha = "fc7a6acf1e9bc09789240385847bcb5af62230ff6ee60a11896075d10a5bff11"
     )
   }
 
@@ -42,7 +42,7 @@ object ShaderTest extends BasicTestSuite {
       Paths.get(shapelessJar),
       resetTimestamp = true,
       expectedClass = expectedShapelessClass,
-      expectedSha = "68ac892591bb30eb2ba5c0c2c3195e7529e15bacd221b8bb3d75b154f5a4ce76"
+      expectedSha = "a72b5de6fd4c0befb0c27423c44cf4645f51d67812a6edc0bb3c6abf0e115105"
     )
   }
 

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/ScalaInlineInfoAttribute.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/ScalaInlineInfoAttribute.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2024 eed3si9n
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eed3si9n.jarjar;
+
+import org.objectweb.asm.Attribute;
+import org.objectweb.asm.ByteVector;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+
+/**
+ * ASM prototype for the Scala compiler's {@code ScalaInlineInfo} class
+ * attribute.
+ *
+ * <p>The attribute stores method names and descriptors as constant-pool UTF8
+ * references. ASM treats attributes it doesn't recognize as opaque byte blobs
+ * and copies them verbatim; because jarjar rebuilds the constant pool of every
+ * class it rewrites, those raw indices go stale and the Scala 2.12/2.13
+ * inliner later fails reading the shaded class with
+ * {@code Error while reading InlineInfoAttribute ... Index N out of bounds for
+ * length N}. Registering this prototype makes ASM parse the references against
+ * the source pool and re-emit them through the destination {@link ClassWriter},
+ * so they stay valid and the inline info is preserved rather than dropped.
+ *
+ * <p>Layout (see {@code scala.tools.nsc.backend.jvm.opt.InlineInfoAttribute}):
+ * <pre>
+ *   u1 version
+ *   u1 flags                       // bit 0x4 =&gt; a SAM name/desc pair follows
+ *   [u2 samName; u2 samDesc]       // present iff (flags &amp; 0x4)
+ *   u2 numEntries
+ *   numEntries * { u2 name; u2 desc; u1 methodFlags }
+ * </pre>
+ *
+ * <p>The descriptor strings are copied unchanged: they name the class's own
+ * members, and on the rare method whose descriptor mentions a relocated type
+ * the entry simply no longer matches that method, so the inliner falls back to
+ * info derived from the bytecode. That is a conservative loss of a hint, never
+ * an incorrect inline.
+ *
+ * <p>Only {@code version} 1 is understood. A future format is left byte-for-byte
+ * as-is (the pre-existing verbatim copy) rather than misparsed, so this stays a
+ * strict improvement even if Scala's layout evolves.
+ */
+public class ScalaInlineInfoAttribute extends Attribute {
+
+    private static final int VERSION = 1;
+    private static final int HAS_SAM = 0x4;
+
+    private int version;
+    private int flags;
+    private String samName;
+    private String samDesc;
+    private String[] names;
+    private String[] descs;
+    private int[] methodFlags;
+    // Non-null iff version is unrecognized: the original bytes, re-emitted as-is.
+    private byte[] verbatim;
+
+    public ScalaInlineInfoAttribute() {
+        super("ScalaInlineInfo");
+    }
+
+    private ScalaInlineInfoAttribute(int version, int flags, String samName, String samDesc,
+                                     String[] names, String[] descs, int[] methodFlags, byte[] verbatim) {
+        super("ScalaInlineInfo");
+        this.version = version;
+        this.flags = flags;
+        this.samName = samName;
+        this.samDesc = samDesc;
+        this.names = names;
+        this.descs = descs;
+        this.methodFlags = methodFlags;
+        this.verbatim = verbatim;
+    }
+
+    @Override
+    protected Attribute read(ClassReader cr, int off, int len, char[] buf, int codeOff, Label[] labels) {
+        int version = cr.readByte(off);
+        if (version != VERSION) {
+            byte[] raw = new byte[len];
+            for (int i = 0; i < len; i++) raw[i] = (byte) cr.readByte(off + i);
+            return new ScalaInlineInfoAttribute(version, 0, null, null, null, null, null, raw);
+        }
+        int p = off + 1;
+        int flags = cr.readByte(p); p += 1;
+        String samName = null;
+        String samDesc = null;
+        if ((flags & HAS_SAM) != 0) {
+            samName = cr.readUTF8(p, buf); p += 2;
+            samDesc = cr.readUTF8(p, buf); p += 2;
+        }
+        int n = cr.readUnsignedShort(p); p += 2;
+        String[] names = new String[n];
+        String[] descs = new String[n];
+        int[] methodFlags = new int[n];
+        for (int i = 0; i < n; i++) {
+            names[i] = cr.readUTF8(p, buf); p += 2;
+            descs[i] = cr.readUTF8(p, buf); p += 2;
+            methodFlags[i] = cr.readByte(p); p += 1;
+        }
+        return new ScalaInlineInfoAttribute(version, flags, samName, samDesc, names, descs, methodFlags, null);
+    }
+
+    @Override
+    protected ByteVector write(ClassWriter cw, byte[] code, int codeLen, int maxStack, int maxLocals) {
+        ByteVector b = new ByteVector();
+        if (verbatim != null) {
+            b.putByteArray(verbatim, 0, verbatim.length);
+            return b;
+        }
+        b.putByte(version);
+        b.putByte(flags);
+        if ((flags & HAS_SAM) != 0) {
+            b.putShort(ref(cw, samName));
+            b.putShort(ref(cw, samDesc));
+        }
+        b.putShort(names.length);
+        for (int i = 0; i < names.length; i++) {
+            b.putShort(ref(cw, names[i]));
+            b.putShort(ref(cw, descs[i]));
+            b.putByte(methodFlags[i]);
+        }
+        return b;
+    }
+
+    private static int ref(ClassWriter cw, String value) {
+        return value == null ? 0 : cw.newUTF8(value);
+    }
+}

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/util/JarTransformer.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/util/JarTransformer.java
@@ -20,7 +20,9 @@ import java.io.*;
 
 import static com.eed3si9n.jarjar.misplaced.MisplacedClassProcessor.VERSIONED_CLASS_FOLDER;
 
+import com.eed3si9n.jarjar.ScalaInlineInfoAttribute;
 import com.eed3si9n.jarjar.TracingRemapper;
+import org.objectweb.asm.Attribute;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -45,7 +47,10 @@ abstract public class JarTransformer extends RemappingJarProcessor {
 
             GetNameClassWriter w = new GetNameClassWriter(ClassWriter.COMPUTE_MAXS);
             try {
-                reader.accept(transform(w, remapper), ClassReader.EXPAND_FRAMES);
+                // Parse Scala's ScalaInlineInfo instead of copying it verbatim, so
+                // its constant-pool references are re-emitted into the rebuilt pool.
+                Attribute[] prototypes = { new ScalaInlineInfoAttribute() };
+                reader.accept(transform(w, remapper), prototypes, ClassReader.EXPAND_FRAMES);
             } catch (RuntimeException e) {
                 throw new IOException("Unable to transform " + struct.name, e);
             }

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
@@ -1,0 +1,157 @@
+package com.eed3si9n.jarjar;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import junit.framework.TestCase;
+import org.junit.Test;
+import com.eed3si9n.jarjar.util.EntryStruct;
+import com.eed3si9n.jarjar.util.IoUtil;
+import com.eed3si9n.jarjar.util.JarTransformerChain;
+import com.eed3si9n.jarjar.util.RemappingClassTransformer;
+
+/**
+ * Shading a class that carries Scala's {@code ScalaInlineInfo} attribute.
+ *
+ * <p>The fixture is {@code shapeless.syntax.HListOps} taken from the shapeless
+ * 2.3.2 jar already vendored under {@code example/} (Scala 2.12, so the
+ * attribute is present). The attribute names methods by constant-pool index;
+ * when jarjar rewrites a class it rebuilds the pool, so those indices must be
+ * re-emitted or they dangle and the Scala 2.12/2.13 inliner fails reading the
+ * shaded class (scalameta/scalameta#3338).
+ */
+public class ScalaInlineInfoTest extends TestCase {
+
+    private static final String FIXTURE_JAR = "example/shapeless_2.12-2.3.2.jar";
+    private static final String FIXTURE_ENTRY = "shapeless/syntax/HListOps.class";
+
+    private static byte[] fixture() throws IOException {
+        ZipFile zf = new ZipFile(FIXTURE_JAR);
+        try {
+            ZipEntry entry = zf.getEntry(FIXTURE_ENTRY);
+            assertNotNull(FIXTURE_ENTRY + " missing from " + FIXTURE_JAR, entry);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            IoUtil.pipe(zf.getInputStream(entry), out, new byte[0x2000]);
+            return out.toByteArray();
+        } finally {
+            zf.close();
+        }
+    }
+
+    private static byte[] shade(byte[] classBytes) throws IOException {
+        EntryStruct e = new EntryStruct();
+        e.name = FIXTURE_ENTRY;
+        e.skipTransform = false;
+        e.time = 0;
+        e.data = classBytes;
+        // Rename the fixture's own package so jarjar rewrites the class and
+        // rebuilds its constant pool; classes it need not touch are copied
+        // verbatim, leaving the attribute trivially intact.
+        Rule rule = new Rule();
+        rule.setPattern("shapeless.**");
+        rule.setResult("shaded.shapeless.@1");
+        PackageRemapper pr = new PackageRemapper(Arrays.asList(rule), false);
+        new JarTransformerChain(new RemappingClassTransformer[] { new RemappingClassTransformer() }, pr)
+            .process(e);
+        return e.data;
+    }
+
+    /**
+     * The method name+descriptor pairs recoverable from the class's
+     * ScalaInlineInfo attribute, resolving each reference against that same
+     * class's constant pool. References that fall out of range or land on a
+     * non-UTF8 entry (i.e. dangling after a pool rebuild) are dropped.
+     */
+    private static Set<String> inlineInfoMethods(byte[] b) {
+        int cpCount = u2(b, 8);
+        int[] tag = new int[cpCount];
+        String[] utf8 = new String[cpCount];
+        int off = 10;
+        for (int i = 1; i < cpCount; i++) {
+            tag[i] = b[off++] & 0xff;
+            switch (tag[i]) {
+                case 1: {
+                    int len = u2(b, off);
+                    off += 2;
+                    utf8[i] = new String(b, off, len, StandardCharsets.UTF_8);
+                    off += len;
+                    break;
+                }
+                case 7: case 8: case 16: case 19: case 20: off += 2; break;
+                case 15: off += 3; break;
+                case 3: case 4: case 9: case 10: case 11: case 12: case 17: case 18: off += 4; break;
+                case 5: case 6: off += 8; i++; break; // long/double take two slots
+                default: throw new IllegalStateException("unexpected constant pool tag " + tag[i]);
+            }
+        }
+        off += 6; // access_flags, this_class, super_class
+        off += 2 + 2 * u2(b, off); // interfaces
+        off = skipMembers(b, off); // fields
+        off = skipMembers(b, off); // methods
+        Set<String> methods = new LinkedHashSet<String>();
+        int nAttrs = u2(b, off);
+        off += 2;
+        for (int i = 0; i < nAttrs; i++) {
+            int nameIdx = u2(b, off);
+            int len = u4(b, off + 2);
+            int data = off + 6;
+            if ("ScalaInlineInfo".equals(utf8[nameIdx]) && (b[data] & 0xff) == 1) {
+                int p = data + 1;
+                int flags = b[p] & 0xff;
+                p += 1;
+                if ((flags & 0x4) != 0) p += 4; // SAM name+desc: not a method entry
+                int n = u2(b, p);
+                p += 2;
+                for (int m = 0; m < n; m++) {
+                    String name = resolve(tag, utf8, cpCount, u2(b, p));
+                    String desc = resolve(tag, utf8, cpCount, u2(b, p + 2));
+                    p += 5;
+                    if (name != null && desc != null) methods.add(name + desc);
+                }
+            }
+            off = data + len;
+        }
+        return methods;
+    }
+
+    private static String resolve(int[] tag, String[] utf8, int cpCount, int idx) {
+        return (idx >= 1 && idx < cpCount && tag[idx] == 1) ? utf8[idx] : null;
+    }
+
+    private static int skipMembers(byte[] b, int off) {
+        int n = u2(b, off);
+        off += 2;
+        for (int i = 0; i < n; i++) {
+            int a = u2(b, off + 6); // access, name, descriptor, then attribute_count
+            off += 8;
+            for (int j = 0; j < a; j++) off += 6 + u4(b, off + 2);
+        }
+        return off;
+    }
+
+    private static int u2(byte[] b, int p) {
+        return ((b[p] & 0xff) << 8) | (b[p + 1] & 0xff);
+    }
+
+    private static int u4(byte[] b, int p) {
+        return ((b[p] & 0xff) << 24) | ((b[p + 1] & 0xff) << 16) | ((b[p + 2] & 0xff) << 8) | (b[p + 3] & 0xff);
+    }
+
+    @Test
+    public void testShadeClassWithScalaInlineInfo() throws IOException {
+        byte[] original = fixture();
+        Set<String> before = inlineInfoMethods(original);
+        assertFalse("fixture should carry ScalaInlineInfo method entries", before.isEmpty());
+
+        boolean preserved = before.equals(inlineInfoMethods(shade(original)));
+        // BUG (scalameta/scalameta#3338): jarjar copies ScalaInlineInfo verbatim,
+        // so its references dangle against the rebuilt pool and the method set is
+        // not carried through shading.
+        assertFalse(preserved);
+    }
+}

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
@@ -149,9 +149,9 @@ public class ScalaInlineInfoTest extends TestCase {
         assertFalse("fixture should carry ScalaInlineInfo method entries", before.isEmpty());
 
         boolean preserved = before.equals(inlineInfoMethods(shade(original)));
-        // BUG (scalameta/scalameta#3338): jarjar copies ScalaInlineInfo verbatim,
-        // so its references dangle against the rebuilt pool and the method set is
-        // not carried through shading.
-        assertFalse(preserved);
+        // Parsing and re-emitting ScalaInlineInfo through the rebuilt pool keeps
+        // its references valid, so the method set survives shading intact
+        // (scalameta/scalameta#3338).
+        assertTrue(preserved);
     }
 }


### PR DESCRIPTION
jarjar rebuilds each rewritten class's constant pool, but ASM copies the unrecognized ScalaInlineInfo attribute verbatim, so the pool indices it stores go stale. The Scala 2.12/2.13 inliner then fails reading the shaded class (Index N out of bounds; scalameta/scalameta#3338).

Fix: register an ASM Attribute prototype that re-emits those references through the new pool. Unknown format versions fall back to the old verbatim copy.

Test shades a real ScalaInlineInfo-bearing class and checks its method set survives — committed asserting the bug first, then flipped by the fix.