### PR TITLE
Preserve ScalaInlineInfo self type when shading

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,10 @@ lazy val jarjar = project
       "org.ow2.asm" % "asm-commons" % "9.10.1",
     )
     libraryDependencies ++= junit
+    // Scala 2.11 test fixture: a trait interface whose ScalaInlineInfo carries
+    // a self type (the 0x2 flag Scala 2.12+ dropped). Resolved rather than
+    // vendored so its provenance stays a plain Maven coordinate.
+    libraryDependencies += "io.argonaut" % "argonaut_2.11" % "6.2-RC2" % Test intransitive ()
 
     mainClass := Some("com.eed3si9n.jarjar.Main")
 

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/ScalaInlineInfoAttribute.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/ScalaInlineInfoAttribute.java
@@ -39,11 +39,19 @@ import org.objectweb.asm.Label;
  * <p>Layout (see {@code scala.tools.nsc.backend.jvm.opt.InlineInfoAttribute}):
  * <pre>
  *   u1 version
- *   u1 flags                       // bit 0x4 =&gt; a SAM name/desc pair follows
+ *   u1 flags                       // 0x1 final, 0x2 self type, 0x4 SAM, 0x8 late interfaces
+ *   [u2 selfType]                  // present iff (flags &amp; 0x2)
  *   [u2 samName; u2 samDesc]       // present iff (flags &amp; 0x4)
  *   u2 numEntries
  *   numEntries * { u2 name; u2 desc; u1 methodFlags }
  * </pre>
+ *
+ * <p>The {@code 0x2} self type reference (a trait's {@code traitImplClassSelfType})
+ * is no longer emitted by Scala 2.12+, but classes compiled by Scala 2.11 — e.g.
+ * a trait interface like {@code argonaut.GeneratedEncodeJsons} — still carry it.
+ * Skipping it misreads {@code numEntries} from the wrong offset and walks the
+ * reader off the constant pool. Its value is unused by the inliner, but the u2
+ * must be consumed and re-emitted to keep the layout valid.
  *
  * <p>The descriptor strings are copied unchanged: they name the class's own
  * members, and on the rare method whose descriptor mentions a relocated type
@@ -58,10 +66,12 @@ import org.objectweb.asm.Label;
 public class ScalaInlineInfoAttribute extends Attribute {
 
     private static final int VERSION = 1;
+    private static final int HAS_SELF = 0x2;
     private static final int HAS_SAM = 0x4;
 
     private int version;
     private int flags;
+    private String selfType;
     private String samName;
     private String samDesc;
     private String[] names;
@@ -74,11 +84,12 @@ public class ScalaInlineInfoAttribute extends Attribute {
         super("ScalaInlineInfo");
     }
 
-    private ScalaInlineInfoAttribute(int version, int flags, String samName, String samDesc,
+    private ScalaInlineInfoAttribute(int version, int flags, String selfType, String samName, String samDesc,
                                      String[] names, String[] descs, int[] methodFlags, byte[] verbatim) {
         super("ScalaInlineInfo");
         this.version = version;
         this.flags = flags;
+        this.selfType = selfType;
         this.samName = samName;
         this.samDesc = samDesc;
         this.names = names;
@@ -93,10 +104,14 @@ public class ScalaInlineInfoAttribute extends Attribute {
         if (version != VERSION) {
             byte[] raw = new byte[len];
             for (int i = 0; i < len; i++) raw[i] = (byte) cr.readByte(off + i);
-            return new ScalaInlineInfoAttribute(version, 0, null, null, null, null, null, raw);
+            return new ScalaInlineInfoAttribute(version, 0, null, null, null, null, null, null, raw);
         }
         int p = off + 1;
         int flags = cr.readByte(p); p += 1;
+        String selfType = null;
+        if ((flags & HAS_SELF) != 0) {
+            selfType = cr.readUTF8(p, buf); p += 2;
+        }
         String samName = null;
         String samDesc = null;
         if ((flags & HAS_SAM) != 0) {
@@ -112,7 +127,7 @@ public class ScalaInlineInfoAttribute extends Attribute {
             descs[i] = cr.readUTF8(p, buf); p += 2;
             methodFlags[i] = cr.readByte(p); p += 1;
         }
-        return new ScalaInlineInfoAttribute(version, flags, samName, samDesc, names, descs, methodFlags, null);
+        return new ScalaInlineInfoAttribute(version, flags, selfType, samName, samDesc, names, descs, methodFlags, null);
     }
 
     @Override
@@ -124,6 +139,9 @@ public class ScalaInlineInfoAttribute extends Attribute {
         }
         b.putByte(version);
         b.putByte(flags);
+        if ((flags & HAS_SELF) != 0) {
+            b.putShort(ref(cw, selfType));
+        }
         if ((flags & HAS_SAM) != 0) {
             b.putShort(ref(cw, samName));
             b.putShort(ref(cw, samDesc));

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
@@ -115,6 +115,7 @@ public class ScalaInlineInfoTest extends TestCase {
                 int p = data + 1;
                 int flags = b[p] & 0xff;
                 p += 1;
+                if ((flags & 0x2) != 0) p += 2; // self type: not a method entry
                 if ((flags & 0x4) != 0) p += 4; // SAM name+desc: not a method entry
                 int n = u2(b, p);
                 p += 2;
@@ -171,21 +172,17 @@ public class ScalaInlineInfoTest extends TestCase {
      * A Scala 2.11 trait interface carries a {@code ScalaInlineInfo} whose flags
      * set the {@code 0x2} self-type bit (dropped by Scala 2.12+). The fixture is
      * {@code argonaut.GeneratedEncodeJsons} from argonaut 6.2-RC2 (a resolved
-     * test dependency). The reader does not consume the self-type reference, so
-     * shading misaligns {@code numEntries} and runs off the constant pool.
+     * test dependency). Consuming and re-emitting the self-type reference keeps
+     * {@code numEntries} aligned, so the method set survives shading intact.
      */
     @Test
     public void testShadeScala211TraitWithSelfType() throws IOException {
         byte[] original = classpathFixture("argonaut/GeneratedEncodeJsons.class");
-        try {
-            shade(original, "argonaut/GeneratedEncodeJsons.class", "argonaut.**", "shaded.argonaut.@1");
-            fail("expected shading to run off the constant pool");
-        } catch (IOException expected) {
-            // Specifically the transform failing to read the attribute — not,
-            // say, a FileNotFoundException from a missing fixture.
-            assertTrue(expected.getMessage(), expected.getMessage().contains("Unable to transform"));
-            assertTrue(String.valueOf(expected.getCause()),
-                expected.getCause() instanceof ArrayIndexOutOfBoundsException);
-        }
+        Set<String> before = inlineInfoMethods(original);
+        assertFalse("fixture should carry ScalaInlineInfo method entries", before.isEmpty());
+
+        boolean preserved = before.equals(
+            inlineInfoMethods(shade(original, "argonaut/GeneratedEncodeJsons.class", "argonaut.**", "shaded.argonaut.@1")));
+        assertTrue(preserved);
     }
 }

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
@@ -27,25 +27,22 @@ import com.eed3si9n.jarjar.util.RemappingClassTransformer;
  */
 public class ScalaInlineInfoTest extends TestCase {
 
-    private static final String FIXTURE_JAR = "example/shapeless_2.12-2.3.2.jar";
-    private static final String FIXTURE_ENTRY = "shapeless/syntax/HListOps.class";
-
-    private static byte[] fixture() throws IOException {
-        ZipFile zf = new ZipFile(FIXTURE_JAR);
+    private static byte[] fixture(String jar, String entry) throws IOException {
+        ZipFile zf = new ZipFile(jar);
         try {
-            ZipEntry entry = zf.getEntry(FIXTURE_ENTRY);
-            assertNotNull(FIXTURE_ENTRY + " missing from " + FIXTURE_JAR, entry);
+            ZipEntry ze = zf.getEntry(entry);
+            assertNotNull(entry + " missing from " + jar, ze);
             ByteArrayOutputStream out = new ByteArrayOutputStream();
-            IoUtil.pipe(zf.getInputStream(entry), out, new byte[0x2000]);
+            IoUtil.pipe(zf.getInputStream(ze), out, new byte[0x2000]);
             return out.toByteArray();
         } finally {
             zf.close();
         }
     }
 
-    private static byte[] shade(byte[] classBytes) throws IOException {
+    private static byte[] shade(byte[] classBytes, String entry, String pattern, String result) throws IOException {
         EntryStruct e = new EntryStruct();
-        e.name = FIXTURE_ENTRY;
+        e.name = entry;
         e.skipTransform = false;
         e.time = 0;
         e.data = classBytes;
@@ -53,8 +50,8 @@ public class ScalaInlineInfoTest extends TestCase {
         // rebuilds its constant pool; classes it need not touch are copied
         // verbatim, leaving the attribute trivially intact.
         Rule rule = new Rule();
-        rule.setPattern("shapeless.**");
-        rule.setResult("shaded.shapeless.@1");
+        rule.setPattern(pattern);
+        rule.setResult(result);
         PackageRemapper pr = new PackageRemapper(Arrays.asList(rule), false);
         new JarTransformerChain(new RemappingClassTransformer[] { new RemappingClassTransformer() }, pr)
             .process(e);
@@ -144,11 +141,12 @@ public class ScalaInlineInfoTest extends TestCase {
 
     @Test
     public void testShadeClassWithScalaInlineInfo() throws IOException {
-        byte[] original = fixture();
+        byte[] original = fixture("example/shapeless_2.12-2.3.2.jar", "shapeless/syntax/HListOps.class");
         Set<String> before = inlineInfoMethods(original);
         assertFalse("fixture should carry ScalaInlineInfo method entries", before.isEmpty());
 
-        boolean preserved = before.equals(inlineInfoMethods(shade(original)));
+        boolean preserved = before.equals(
+            inlineInfoMethods(shade(original, "shapeless/syntax/HListOps.class", "shapeless.**", "shaded.shapeless.@1")));
         // Parsing and re-emitting ScalaInlineInfo through the rebuilt pool keeps
         // its references valid, so the method set survives shading intact
         // (scalameta/scalameta#3338).

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
@@ -2,6 +2,7 @@ package com.eed3si9n.jarjar;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -37,6 +38,19 @@ public class ScalaInlineInfoTest extends TestCase {
             return out.toByteArray();
         } finally {
             zf.close();
+        }
+    }
+
+    /** Reads a .class file off the test classpath (from a resolved fixture dependency). */
+    private static byte[] classpathFixture(String entry) throws IOException {
+        InputStream in = ScalaInlineInfoTest.class.getClassLoader().getResourceAsStream(entry);
+        assertNotNull(entry + " not on the test classpath", in);
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            IoUtil.pipe(in, out, new byte[0x2000]);
+            return out.toByteArray();
+        } finally {
+            in.close();
         }
     }
 
@@ -151,5 +165,27 @@ public class ScalaInlineInfoTest extends TestCase {
         // its references valid, so the method set survives shading intact
         // (scalameta/scalameta#3338).
         assertTrue(preserved);
+    }
+
+    /**
+     * A Scala 2.11 trait interface carries a {@code ScalaInlineInfo} whose flags
+     * set the {@code 0x2} self-type bit (dropped by Scala 2.12+). The fixture is
+     * {@code argonaut.GeneratedEncodeJsons} from argonaut 6.2-RC2 (a resolved
+     * test dependency). The reader does not consume the self-type reference, so
+     * shading misaligns {@code numEntries} and runs off the constant pool.
+     */
+    @Test
+    public void testShadeScala211TraitWithSelfType() throws IOException {
+        byte[] original = classpathFixture("argonaut/GeneratedEncodeJsons.class");
+        try {
+            shade(original, "argonaut/GeneratedEncodeJsons.class", "argonaut.**", "shaded.argonaut.@1");
+            fail("expected shading to run off the constant pool");
+        } catch (IOException expected) {
+            // Specifically the transform failing to read the attribute — not,
+            // say, a FileNotFoundException from a missing fixture.
+            assertTrue(expected.getMessage(), expected.getMessage().contains("Unable to transform"));
+            assertTrue(String.valueOf(expected.getCause()),
+                expected.getCause() instanceof ArrayIndexOutOfBoundsException);
+        }
     }
 }


### PR DESCRIPTION
Scala 2.11 emits a traitImplClassSelfType u2 reference, gated by the 0x2 flag bit, before the SAM and method entries. The reader ignored it, so numEntries was read two bytes early as a garbage count and readUTF8 ran off the constant pool (ArrayIndexOutOfBoundsException). Consume the reference and re-emit it through the rebuilt pool. Scala 2.12+ no longer writes it, which is why 2.12 fixtures never exposed this.