### PR TITLE
Fall back to verbatim on an unparsed ScalaInlineInfo

### DIFF
--- a/jarjar/src/main/java/com/eed3si9n/jarjar/ScalaInlineInfoAttribute.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/ScalaInlineInfoAttribute.java
@@ -101,11 +101,15 @@ public class ScalaInlineInfoAttribute extends Attribute {
     @Override
     protected Attribute read(ClassReader cr, int off, int len, char[] buf, int codeOff, Label[] labels) {
         int version = cr.readByte(off);
-        if (version != VERSION) {
-            byte[] raw = new byte[len];
-            for (int i = 0; i < len; i++) raw[i] = (byte) cr.readByte(off + i);
-            return new ScalaInlineInfoAttribute(version, 0, null, null, null, null, null, null, raw);
+        if (version == VERSION) {
+            return readVersion1(cr, off, len, buf);
         }
+        byte[] raw = new byte[len];
+        for (int i = 0; i < len; i++) raw[i] = (byte) cr.readByte(off + i);
+        return new ScalaInlineInfoAttribute(version, 0, null, null, null, null, null, null, raw);
+    }
+
+    private ScalaInlineInfoAttribute readVersion1(ClassReader cr, int off, int len, char[] buf) {
         int p = off + 1;
         int flags = cr.readByte(p); p += 1;
         String selfType = null;
@@ -127,7 +131,7 @@ public class ScalaInlineInfoAttribute extends Attribute {
             descs[i] = cr.readUTF8(p, buf); p += 2;
             methodFlags[i] = cr.readByte(p); p += 1;
         }
-        return new ScalaInlineInfoAttribute(version, flags, selfType, samName, samDesc, names, descs, methodFlags, null);
+        return new ScalaInlineInfoAttribute(VERSION, flags, selfType, samName, samDesc, names, descs, methodFlags, null);
     }
 
     @Override

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/ScalaInlineInfoAttribute.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/ScalaInlineInfoAttribute.java
@@ -59,9 +59,11 @@ import org.objectweb.asm.Label;
  * info derived from the bytecode. That is a conservative loss of a hint, never
  * an incorrect inline.
  *
- * <p>Only {@code version} 1 is understood. A future format is left byte-for-byte
- * as-is (the pre-existing verbatim copy) rather than misparsed, so this stays a
- * strict improvement even if Scala's layout evolves.
+ * <p>Only {@code version} 1 is understood, and only a layout that parses cleanly
+ * and consumes exactly the attribute length is re-emitted. Anything else — a
+ * future version, a v1 layout that doesn't add up, or references that run off
+ * the pool — is left byte-for-byte as-is (a verbatim copy) rather than
+ * misparsed, so this stays a strict improvement even if Scala's layout evolves.
  */
 public class ScalaInlineInfoAttribute extends Attribute {
 
@@ -102,7 +104,13 @@ public class ScalaInlineInfoAttribute extends Attribute {
     protected Attribute read(ClassReader cr, int off, int len, char[] buf, int codeOff, Label[] labels) {
         int version = cr.readByte(off);
         if (version == VERSION) {
-            return readVersion1(cr, off, len, buf);
+            try {
+                ScalaInlineInfoAttribute parsed = readVersion1(cr, off, len, buf);
+                if (parsed != null) return parsed;
+            } catch (RuntimeException layoutNotUnderstood) {
+                // References ran off the constant pool: the layout isn't one we
+                // model. Fall through to the verbatim copy below.
+            }
         }
         byte[] raw = new byte[len];
         for (int i = 0; i < len; i++) raw[i] = (byte) cr.readByte(off + i);
@@ -131,6 +139,11 @@ public class ScalaInlineInfoAttribute extends Attribute {
             descs[i] = cr.readUTF8(p, buf); p += 2;
             methodFlags[i] = cr.readByte(p); p += 1;
         }
+        // A layout we understand is consumed exactly. If our offsets disagree
+        // with the declared length, this class uses a format we don't model;
+        // return null so read() copies it verbatim rather than re-emit a
+        // truncated/mis-encoded attribute.
+        if (p - off != len) return null;
         return new ScalaInlineInfoAttribute(VERSION, flags, selfType, samName, samDesc, names, descs, methodFlags, null);
     }
 

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
@@ -11,6 +11,10 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import junit.framework.TestCase;
 import org.junit.Test;
+import org.objectweb.asm.Attribute;
+import org.objectweb.asm.ByteVector;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
 import com.eed3si9n.jarjar.util.EntryStruct;
 import com.eed3si9n.jarjar.util.IoUtil;
 import com.eed3si9n.jarjar.util.JarTransformerChain;
@@ -184,5 +188,80 @@ public class ScalaInlineInfoTest extends TestCase {
         boolean preserved = before.equals(
             inlineInfoMethods(shade(original, "argonaut/GeneratedEncodeJsons.class", "argonaut.**", "shaded.argonaut.@1")));
         assertTrue(preserved);
+    }
+
+    /** A minimal class carrying {@code attr} bytes as its ScalaInlineInfo attribute. */
+    private static byte[] classWithRawInlineInfo(final byte[] attr) {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "pkg/Widget", null, "java/lang/Object", null);
+        cw.visitAttribute(new Attribute("ScalaInlineInfo") {
+            @Override
+            protected ByteVector write(ClassWriter cw, byte[] code, int codeLen, int maxStack, int maxLocals) {
+                return new ByteVector().putByteArray(attr, 0, attr.length);
+            }
+        });
+        cw.visitEnd();
+        return cw.toByteArray();
+    }
+
+    /** The raw payload bytes of the class's ScalaInlineInfo attribute, or null. */
+    private static byte[] inlineInfoAttrBytes(byte[] b) {
+        int cpCount = u2(b, 8);
+        String[] utf8 = new String[cpCount];
+        int off = 10;
+        for (int i = 1; i < cpCount; i++) {
+            int tag = b[off++] & 0xff;
+            switch (tag) {
+                case 1: {
+                    int len = u2(b, off);
+                    off += 2;
+                    utf8[i] = new String(b, off, len, StandardCharsets.UTF_8);
+                    off += len;
+                    break;
+                }
+                case 7: case 8: case 16: case 19: case 20: off += 2; break;
+                case 15: off += 3; break;
+                case 3: case 4: case 9: case 10: case 11: case 12: case 17: case 18: off += 4; break;
+                case 5: case 6: off += 8; i++; break;
+                default: throw new IllegalStateException("unexpected constant pool tag " + tag);
+            }
+        }
+        off += 6;
+        off += 2 + 2 * u2(b, off);
+        off = skipMembers(b, off);
+        off = skipMembers(b, off);
+        int nAttrs = u2(b, off);
+        off += 2;
+        for (int i = 0; i < nAttrs; i++) {
+            int nameIdx = u2(b, off);
+            int len = u4(b, off + 2);
+            int data = off + 6;
+            if ("ScalaInlineInfo".equals(utf8[nameIdx])) return Arrays.copyOfRange(b, data, data + len);
+            off = data + len;
+        }
+        return null;
+    }
+
+    /**
+     * A ScalaInlineInfo whose {@code 0x4} SAM flag points its name reference off
+     * the constant pool: version 1, but a layout the reader can't resolve. The
+     * reader follows the bogus reference and the transform currently throws.
+     */
+    @Test
+    public void testUnrecognizedInlineInfoLayout() throws IOException {
+        byte[] attr = { 1, 0x4, (byte) 0xff, (byte) 0xff, 0, 0 }; // version, flags=SAM, bogus samName, samDesc=0
+        byte[] original = classWithRawInlineInfo(attr);
+        assertNotNull(inlineInfoAttrBytes(original));
+
+        try {
+            shade(original, "pkg/Widget.class", "pkg.**", "shaded.pkg.@1");
+            fail("expected the reader to run off the constant pool");
+        } catch (IOException expected) {
+            // Specifically the transform failing to read the attribute — not,
+            // say, a FileNotFoundException from a missing fixture.
+            assertTrue(expected.getMessage(), expected.getMessage().contains("Unable to transform"));
+            assertTrue(String.valueOf(expected.getCause()),
+                expected.getCause() instanceof ArrayIndexOutOfBoundsException);
+        }
     }
 }

--- a/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
+++ b/jarjar/src/test/java/com/eed3si9n/jarjar/ScalaInlineInfoTest.java
@@ -244,8 +244,8 @@ public class ScalaInlineInfoTest extends TestCase {
 
     /**
      * A ScalaInlineInfo whose {@code 0x4} SAM flag points its name reference off
-     * the constant pool: version 1, but a layout the reader can't resolve. The
-     * reader follows the bogus reference and the transform currently throws.
+     * the constant pool: version 1, but a layout the reader can't resolve. It is
+     * copied verbatim rather than crashing the transform.
      */
     @Test
     public void testUnrecognizedInlineInfoLayout() throws IOException {
@@ -253,15 +253,7 @@ public class ScalaInlineInfoTest extends TestCase {
         byte[] original = classWithRawInlineInfo(attr);
         assertNotNull(inlineInfoAttrBytes(original));
 
-        try {
-            shade(original, "pkg/Widget.class", "pkg.**", "shaded.pkg.@1");
-            fail("expected the reader to run off the constant pool");
-        } catch (IOException expected) {
-            // Specifically the transform failing to read the attribute — not,
-            // say, a FileNotFoundException from a missing fixture.
-            assertTrue(expected.getMessage(), expected.getMessage().contains("Unable to transform"));
-            assertTrue(String.valueOf(expected.getCause()),
-                expected.getCause() instanceof ArrayIndexOutOfBoundsException);
-        }
+        byte[] shaded = shade(original, "pkg/Widget.class", "pkg.**", "shaded.pkg.@1");
+        assertTrue(Arrays.equals(attr, inlineInfoAttrBytes(shaded)));
     }
 }


### PR DESCRIPTION
readVersion1 now returns null unless it consumes exactly the attribute length, and read() treats that (and any constant-pool exception) as a signal to copy the attribute byte-for-byte. A layout we don't model (a future version, a stale index, a flag we don't handle) degrades to a no-op rather than corrupting output or crashing the transform — the failure mode that hid the self-type bug.
