### PR TITLE
Keep original bytes when no Scala signature was rewritten

### DIFF
--- a/core/src/main/scala/com/eed3si9n/jarjar/ScalaSigProcessor.scala
+++ b/core/src/main/scala/com/eed3si9n/jarjar/ScalaSigProcessor.scala
@@ -11,9 +11,15 @@ class ScalaSigProcessor(renamer: String => Option[String]) extends JarProcessor 
     else {
       val classWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS)
       val reader = new ClassReader(struct.data)
+      val visitor = new ScalaSigClassVisitor(classWriter, renamer)
 
-      reader.accept(new ScalaSigClassVisitor(classWriter, renamer), ClassReader.EXPAND_FRAMES)
-      struct.data = classWriter.toByteArray
+      reader.accept(visitor, ClassReader.EXPAND_FRAMES)
+      // Only take the re-emitted bytes when a Scala signature was actually rewritten. Going
+      // through ASM rebuilds the constant pool from scratch, which reorders it and can widen
+      // ldc into ldc_w; classes this processor has nothing to do with -- every Java class, and
+      // every Scala class the rules leave alone -- would otherwise come out of shading
+      // gratuitously different from their input, for no change in behaviour.
+      if (visitor.hasChanges) struct.data = classWriter.toByteArray
       true
     }
   }

--- a/core/src/main/scala/com/eed3si9n/jarjarabrams/scalasig/EntryTable.scala
+++ b/core/src/main/scala/com/eed3si9n/jarjarabrams/scalasig/EntryTable.scala
@@ -34,8 +34,11 @@ class EntryTable(majorVersion: Int, minorVersion: Int, entries: mutable.Buffer[T
    * Unused entries will not be removed from the table.
    *
    * @param renamer renames a fully qualified type or term name or return None if it does not match.
+   * @return true if at least one entry was renamed to a different name, false if the table came
+   *         out of this untouched.
    */
-  def renameEntries(renamer: String => Option[String]): Unit = {
+  def renameEntries(renamer: String => Option[String]): Boolean = {
+    var renamedAny = false
 
     entries.zipWithIndex.collect { case (ref: RefEntry, index) =>
       entries(ref.nameRef) match {
@@ -43,7 +46,9 @@ class EntryTable(majorVersion: Int, minorVersion: Int, entries: mutable.Buffer[T
           for {
             fqName <- resolveRef(ref)
             renamed <- renamer(fqName)
+            if renamed != fqName
           } {
+            renamedAny = true
             val parts = renamed.split('.')
 
             val myOwner = parts.init.foldLeft(Option.empty[Int]) { (owner, part) =>
@@ -62,6 +67,8 @@ class EntryTable(majorVersion: Int, minorVersion: Int, entries: mutable.Buffer[T
           throw new RuntimeException(s"Ref entry does not point to a name but to a ${other.tag}")
       }
     }
+
+    renamedAny
   }
 
   // Return existing name entry or append a new one.

--- a/core/src/main/scala/com/eed3si9n/jarjarabrams/scalasig/ScalaSigAnnotationVisitor.scala
+++ b/core/src/main/scala/com/eed3si9n/jarjarabrams/scalasig/ScalaSigAnnotationVisitor.scala
@@ -5,16 +5,28 @@ import java.io.ByteArrayOutputStream
 
 import org.objectweb.asm.{ AnnotationVisitor, ClassVisitor, Opcodes }
 
+import scala.collection.mutable
 import scala.reflect.internal.pickling.ByteCodecs
 
 class ScalaSigClassVisitor(cv: ClassVisitor, renamer: String => Option[String])
     extends ClassVisitor(Opcodes.ASM9, cv) {
 
+  private val sigVisitors = mutable.ListBuffer.empty[ScalaSigAnnotationVisitor]
+
+  /**
+   * Whether a Scala signature was actually rewritten. False for a class that carries no Scala
+   * signature at all, and for one whose signature the renamer left alone -- in both cases what
+   * this visitor emitted is a plain copy of what it read.
+   */
+  def hasChanges: Boolean = sigVisitors.exists(_.hasChanges)
+
   override def visitAnnotation(descriptor: String, visible: Boolean): AnnotationVisitor = {
     if (
       descriptor == "Lscala/reflect/ScalaSignature;" || descriptor == "Lscala/reflect/ScalaLongSignature;"
     ) {
-      new ScalaSigAnnotationVisitor(visible, cv, renamer)
+      val visitor = new ScalaSigAnnotationVisitor(visible, cv, renamer)
+      sigVisitors += visitor
+      visitor
     } else {
       super.visitAnnotation(descriptor, visible)
     }
@@ -31,6 +43,10 @@ class ScalaSigAnnotationVisitor(
   private val MaxStringSizeInBytes = 65535
   private val annotationBytes: ByteArrayOutputStream = new ByteArrayOutputStream()
   private var hasWrittenAnnotation = false
+  private var changed = false
+
+  /** Whether the signature this visitor re-emitted differs from the one it read. */
+  def hasChanges: Boolean = changed
 
   override def visit(name: String, value: Any): Unit = {
     // Append all the annotation bytes, whether is is a long or normal signature
@@ -57,7 +73,7 @@ class ScalaSigAnnotationVisitor(
     val len = ByteCodecs.decode(encoded)
 
     val table = EntryTable.fromBytes(encoded.slice(0, len))
-    table.renameEntries(renamer)
+    changed = table.renameEntries(renamer)
 
     val chars = ubytesToCharArray(mapToNextModSevenBits(ByteCodecs.encode8to7(table.toBytes)))
     val utf8EncodedLength = chars.foldLeft(0) { (count, next) =>

--- a/core/src/test/scala/testpkg/EntryTableSpec.scala
+++ b/core/src/test/scala/testpkg/EntryTableSpec.scala
@@ -28,20 +28,34 @@ object EntryTableSpec extends BasicTestSuite {
     val len = ByteCodecs.decode(bytes)
     val table = EntryTable.fromBytes(bytes.slice(0, len))
 
-    table.renameEntries {
+    assert(table.renameEntries {
       case pckg if pckg.startsWith("testpkg") => Some("shaded.testpkg")
       case _                                  => None
-    }
+    })
 
     assert(resolveName(table, "Test") == Some("shaded.testpkg.Test"))
 
-    table.renameEntries {
+    assert(table.renameEntries {
       case pckg if pckg.startsWith("shaded.testpkg") =>
         Some("testpkg.shadedtoo")
       case _ => None
-    }
+    })
 
     assert(resolveName(table, "Test") == Some("testpkg.shadedtoo.Test"))
+  }
+
+  test("entry table should report when it renamed nothing") {
+    val encoded = classOf[Test2].getAnnotation(classOf[ScalaSignature])
+    val bytes = encoded.bytes().getBytes("UTF-8")
+
+    val len = ByteCodecs.decode(bytes)
+    val table = EntryTable.fromBytes(bytes.slice(0, len))
+    val before = table.toSeq
+
+    assert(!table.renameEntries(_ => None))
+    // a renamer that "matches" but hands back the same name is not a rename either
+    assert(!table.renameEntries(Some(_)))
+    assert(table.toSeq == before)
   }
 
   test("entry table should return same serialized bytes") {

--- a/core/src/test/scala/testpkg/ShaderTest.scala
+++ b/core/src/test/scala/testpkg/ShaderTest.scala
@@ -1,8 +1,11 @@
 package testpkg
 
 import verify._
+import java.io.{ ByteArrayOutputStream, InputStream }
 import java.nio.file.{ Files, Path, Paths }
-import com.eed3si9n.jarjarabrams.{ Shader, Zip }
+import java.util.Arrays
+import java.util.zip.ZipFile
+import com.eed3si9n.jarjarabrams.{ ShadeRule, Shader, Zip }
 
 object ShaderTest extends BasicTestSuite {
   final val byteBuddyJar = "example/byte-buddy-agent.jar"
@@ -33,7 +36,7 @@ object ShaderTest extends BasicTestSuite {
       Paths.get(shapelessJar),
       resetTimestamp = false,
       expectedClass = expectedShapelessClass,
-      expectedSha = "fc7a6acf1e9bc09789240385847bcb5af62230ff6ee60a11896075d10a5bff11"
+      expectedSha = "92c0bb157f07c0f09e4cf8cfed7d88ad68131c64a664d7afac4de83d71840e3f"
     )
   }
 
@@ -42,8 +45,75 @@ object ShaderTest extends BasicTestSuite {
       Paths.get(shapelessJar),
       resetTimestamp = true,
       expectedClass = expectedShapelessClass,
-      expectedSha = "a72b5de6fd4c0befb0c27423c44cf4645f51d67812a6edc0bb3c6abf0e115105"
+      expectedSha = "e7277b6ac841dad397183516e584e5458186e23c28181fb42b8832d2d3f57564"
     )
+  }
+
+  test("leave Java classes no rule matches byte-for-byte alone") {
+    assertUnmatchedClassesUnchanged(
+      Paths.get(byteBuddyJar),
+      ShadeRule.rename("shapeless.**" -> "bar.shapeless.@1").inAll
+    )
+  }
+
+  test("leave Scala classes no rule matches byte-for-byte alone") {
+    assertUnmatchedClassesUnchanged(
+      Paths.get(shapelessJar),
+      ShadeRule.rename("net.bytebuddy.agent.**" -> "foo.@1").inAll
+    )
+  }
+
+  /**
+   * Shading a jar with rules that match none of it has to hand back the classes it was given.
+   * Reading a class with ASM and writing it back rebuilds the constant pool, which reorders it and
+   * can widen ldc into ldc_w -- a difference in the output for no difference in behaviour.
+   */
+  def assertUnmatchedClassesUnchanged(inJar: Path, rules: ShadeRule*): Unit = {
+    val tempJar = Files.createTempFile("test", ".jar")
+    Shader.shadeFile(
+      rules.toList,
+      inJar,
+      tempJar,
+      verbose = false,
+      skipManifest = false,
+      resetTimestamp = false,
+      warnOnDuplicateClass = false
+    )
+    val before = classEntries(inJar)
+    val after = classEntries(tempJar)
+    assert(before.keySet == after.keySet)
+    val rewritten = before.collect {
+      case (name, bytes) if !Arrays.equals(bytes, after(name)) => name
+    }
+    assert(rewritten.isEmpty)
+  }
+
+  def classEntries(jar: Path): Map[String, Array[Byte]] = {
+    val zip = new ZipFile(jar.toFile)
+    try {
+      val builder = Map.newBuilder[String, Array[Byte]]
+      val entries = zip.entries()
+      while (entries.hasMoreElements) {
+        val entry = entries.nextElement()
+        if (entry.getName.endsWith(".class")) {
+          val in = zip.getInputStream(entry)
+          try builder += entry.getName -> readAll(in)
+          finally in.close()
+        }
+      }
+      builder.result()
+    } finally zip.close()
+  }
+
+  def readAll(in: InputStream): Array[Byte] = {
+    val out = new ByteArrayOutputStream()
+    val buffer = new Array[Byte](8192)
+    var read = in.read(buffer)
+    while (read >= 0) {
+      out.write(buffer, 0, read)
+      read = in.read(buffer)
+    }
+    out.toByteArray
   }
 
   def testShading(


### PR DESCRIPTION
This fixes a problem I've been running into when doing byte-for-byte comparisons of JARs, with some of them processed by jarjar-abrams.

It seems jarjar-abrams was rewriting all classes that have Scala annotations, even those that don't need to be rewritten. This was making them different when doing byte-for-byte comparisons with the original classes, even though shading wasn't supposed to change anything in these classes. This PR fixes that.