### PR TITLE
Let the misplaced-class strategy see unreadable classes

### DIFF
--- a/core/src/main/scala/com/eed3si9n/jarjarabrams/Shader.scala
+++ b/core/src/main/scala/com/eed3si9n/jarjarabrams/Shader.scala
@@ -68,6 +68,19 @@ object Shader {
       verbose: Boolean,
       skipManifest: Boolean
   ): (Array[Byte], String) => Option[(Array[Byte], String)] =
+    bytecodeShader(rules, verbose, skipManifest, misplacedClassStrategy = None)
+
+  /**
+   * @param misplacedClassStrategy how to treat entries that cannot be shaded, one of the
+   *                               `MisplacedClassProcessorFactory.Strategy` names. `None` keeps the
+   *                               default, which omits them.
+   */
+  def bytecodeShader(
+      rules: Seq[ShadeRule],
+      verbose: Boolean,
+      skipManifest: Boolean,
+      misplacedClassStrategy: Option[String]
+  ): (Array[Byte], String) => Option[(Array[Byte], String)] =
     if (rules.isEmpty) (bytes, mapping) => Some(bytes -> mapping)
     else {
       val jjrules = rules.flatMap { r =>
@@ -99,7 +112,7 @@ object Shader {
         patterns = jjrules,
         verbose = verbose,
         skipManifest = skipManifest,
-        misplacedClassStrategy = null
+        misplacedClassStrategy = misplacedClassStrategy.orNull
       )
       val excludes = proc.getExcludes
 

--- a/core/src/test/scala/testpkg/ShaderTest.scala
+++ b/core/src/test/scala/testpkg/ShaderTest.scala
@@ -88,6 +88,34 @@ object ShaderTest extends BasicTestSuite {
     assert(rewritten.isEmpty)
   }
 
+  test("keep unshadeable entries by default") {
+    val shader = Shader.bytecodeShader(shadeRules, verbose = false, skipManifest = false)
+    assert(shader(unreadableClass, "payload/Unreadable.class").isDefined)
+    assert(shader(sampleClass, "payload/Misplaced.class").isEmpty)
+  }
+
+  test("fail on unshadeable entries under the fatal strategy") {
+    val shader =
+      Shader.bytecodeShader(shadeRules, verbose = false, skipManifest = false, Some("fatal"))
+    intercept[RuntimeException] {
+      shader(unreadableClass, "payload/Unreadable.class")
+    }
+    intercept[RuntimeException] {
+      shader(sampleClass, "payload/Misplaced.class")
+    }
+  }
+
+  lazy val shadeRules = List(ShadeRule.rename("payload.**" -> "shadedpayload.@1").inAll)
+
+  lazy val sampleClass = classEntries(Paths.get(byteBuddyJar)).head._2
+
+  lazy val unreadableClass = {
+    val bytes = sampleClass.clone()
+    bytes(6) = 0.toByte
+    bytes(7) = 99.toByte
+    bytes
+  }
+
   def classEntries(jar: Path): Map[String, Array[Byte]] = {
     val zip = new ZipFile(jar.toFile)
     try {

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/misplaced/FatalMisplacedClassProcessor.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/misplaced/FatalMisplacedClassProcessor.java
@@ -19,9 +19,21 @@ public class FatalMisplacedClassProcessor extends MisplacedClassProcessor {
     return false;
   }
 
-  static class FatalMisplacedClassException extends RuntimeException {
+  @Override public void handleUnreadableClass(EntryStruct classStruct, Exception cause) {
+    throw new FatalMisplacedClassException(
+        "Unable to read classname from bytecode in " + classStruct.name
+            + ", so shading it is impossible ("
+            + cause.getClass().getName() + ": " + cause.getMessage() + ")",
+        cause);
+  }
+
+  public static class FatalMisplacedClassException extends RuntimeException {
     FatalMisplacedClassException(String message) {
       super(message);
+    }
+
+    FatalMisplacedClassException(String message, Throwable cause) {
+      super(message, cause);
     }
   }
 

--- a/jarjar/src/main/java/com/eed3si9n/jarjar/misplaced/MisplacedClassProcessor.java
+++ b/jarjar/src/main/java/com/eed3si9n/jarjar/misplaced/MisplacedClassProcessor.java
@@ -31,6 +31,18 @@ public abstract class MisplacedClassProcessor implements JarProcessor {
    */
   public abstract boolean shouldKeep();
 
+  /**
+   * Handles a class whose fully-qualified name cannot be read out of its bytecode, which leaves it
+   * unshaded no matter which strategy is in effect.
+   * @param classStruct The jar EntryStruct for the class.
+   * @param cause The failure raised while reading the class name.
+   */
+  public void handleUnreadableClass(EntryStruct classStruct, Exception cause) {
+    System.err.println("Unable to read classname from bytecode in " + classStruct.name);
+    System.err.println("Shading is therefore impossible, so this entry will be skipped.");
+    System.err.println(cause.getClass().getName() + ": " + cause.getMessage());
+  }
+
   @Override public boolean process(EntryStruct struct)
       throws IOException {
     if (!struct.name.endsWith(".class")) return true;
@@ -39,9 +51,7 @@ public abstract class MisplacedClassProcessor implements JarProcessor {
     try {
       originalClassName = new ClassReader(struct.data).getClassName() + ".class";
     } catch (Exception e) {
-      System.err.println("Unable to read classname from bytecode in " + struct.name);
-      System.err.println("Shading is therefore impossible, so this entry will be skipped.");
-      System.err.println(e.getClass().getName() + ": " + e.getMessage());
+      handleUnreadableClass(struct, e);
       struct.skipTransform = true;
       return true;
     }


### PR DESCRIPTION
When ClassReader can't read a class name, MisplacedClassProcessor prints to stderr and skips the entry, so no strategy ever sees it. Adds a handleUnreadableClass hook, overridden by fatal, and lets Shader.bytecodeShader take a misplacedClassStrategy. Downstream this is what sbt/sbt-assembly#586 needs.